### PR TITLE
Make nginx timeouts configurable

### DIFF
--- a/roles/proxy/defaults/main.yml
+++ b/roles/proxy/defaults/main.yml
@@ -35,3 +35,9 @@ proxy_generate_dh_param: true
 
 # Used for the /mailto enpoint - Has to be a valid mail address.
 proxy_mailto:
+
+
+proxy_send_timeout: "900s"
+proxy_read_timeout: "900s"
+fastcgi_send_timeout: "900s"
+fastcgi_read_timeout: "900s"

--- a/roles/proxy/templates/nginx_timeouts.conf.j2
+++ b/roles/proxy/templates/nginx_timeouts.conf.j2
@@ -1,6 +1,6 @@
 {{ ansible_managed | comment }}
 
-proxy_send_timeout 900s;
-proxy_read_timeout 900s;
-fastcgi_send_timeout 900s;
-fastcgi_read_timeout 900s;
+proxy_send_timeout {{ proxy_send_timeout }};
+proxy_read_timeout {{ proxy_read_timeout }};
+fastcgi_send_timeout {{ fastcgi_send_timeout }};
+fastcgi_read_timeout {{ fastcgi_read_timeout }};


### PR DESCRIPTION
A longer timeout might be needed to support the repository export of large courses.
See https://github.com/ls1intum/Artemis/issues/4454 for details.