### PR TITLE
Add mysqld_exporter role

### DIFF
--- a/roles/mysqld_exporter/README.md
+++ b/roles/mysqld_exporter/README.md
@@ -9,6 +9,7 @@ Role Variables
 --------------
 
 Default variables can be found in the `defaults/main.yml` file.
+
 Important: Change database user password!
 
 Dependencies

--- a/roles/mysqld_exporter/README.md
+++ b/roles/mysqld_exporter/README.md
@@ -1,0 +1,16 @@
+MySQLd Exporter
+=========
+
+Role to setup the [MySQLd exporter](https://github.com/prometheus/mysqld_exporter) for prometheus.
+It creates a user on the MySQL database on the host, which is needed for scraping the data.
+
+
+Role Variables
+--------------
+
+Default variables can be found in the `defaults/main.yml` file.
+Important: Change database user password!
+
+Dependencies
+--------------
+Install all with ```ansible-galaxy install -r meta/requirements.yml´´´

--- a/roles/mysqld_exporter/defaults/main.yml
+++ b/roles/mysqld_exporter/defaults/main.yml
@@ -1,0 +1,6 @@
+mysql_exporter_user: "exporter"
+mysql_exporter_password: "CHANGE THIS"
+
+mysql_exporter_version: "0.14.0"
+mysql_exporter_dsn: "{{ mysql_exporter_user }}:{{ mysql_exporter_password }}@(localhost:3306)/"
+

--- a/roles/mysqld_exporter/defaults/main.yml
+++ b/roles/mysqld_exporter/defaults/main.yml
@@ -1,5 +1,5 @@
 mysql_exporter_user: "exporter"
-mysql_exporter_password: "CHANGE THIS"
+mysql_exporter_password: ""
 
 mysql_exporter_version: "0.14.0"
 mysql_exporter_dsn: "{{ mysql_exporter_user }}:{{ mysql_exporter_password }}@(localhost:3306)/"

--- a/roles/mysqld_exporter/meta/requirements.yml
+++ b/roles/mysqld_exporter/meta/requirements.yml
@@ -1,0 +1,2 @@
+- name: cloudalchemy.mysqld_exporter
+  src: https://github.com/ls1admin/ansible-mysqld_exporter.git

--- a/roles/mysqld_exporter/tasks/main.yml
+++ b/roles/mysqld_exporter/tasks/main.yml
@@ -1,0 +1,19 @@
+# https://docs.ansible.com/ansible/2.9/modules/mysql_user_module.html#mysql-user-module
+#
+# CREATE USER 'exporter'@'localhost' IDENTIFIED BY 'XXXXXXXX' WITH MAX_USER_CONNECTIONS 3;
+# GRANT PROCESS, REPLICATION CLIENT, SELECT ON *.* TO 'exporter'@'localhost';
+
+- name: Create database user with password and PROCESS, REPLICATION CLIENT privileges
+  mysql_user:
+    name: "{{ mysql_exporter_user }}"
+    password: "{{ mysql_exporter_password }}"
+    priv: '*.*:PROCESS,REPLICATION CLIENT'
+    state: present
+
+- name: Install MySQLd exporter
+  include_role:
+    name: cloudalchemy.mysqld_exporter
+  vars:
+    mysqld_exporter_version: "{{ mysql_exporter_version }}"
+    mysqld_exporter_dsn: "{{ mysql_exporter_dsn }}"
+

--- a/roles/mysqld_exporter/tasks/main.yml
+++ b/roles/mysqld_exporter/tasks/main.yml
@@ -1,7 +1,4 @@
-# https://docs.ansible.com/ansible/2.9/modules/mysql_user_module.html#mysql-user-module
-#
-# CREATE USER 'exporter'@'localhost' IDENTIFIED BY 'XXXXXXXX' WITH MAX_USER_CONNECTIONS 3;
-# GRANT PROCESS, REPLICATION CLIENT, SELECT ON *.* TO 'exporter'@'localhost';
+---
 
 - name: Create database user with password and PROCESS, REPLICATION CLIENT privileges
   mysql_user:
@@ -10,7 +7,7 @@
     priv: '*.*:PROCESS,REPLICATION CLIENT'
     state: present
 
-- name: Install MySQLd exporter
+- name: Install mysqld_exporter
   include_role:
     name: cloudalchemy.mysqld_exporter
   vars:

--- a/roles/mysqld_exporter/tasks/main.yml
+++ b/roles/mysqld_exporter/tasks/main.yml
@@ -7,10 +7,9 @@
     priv: '*.*:PROCESS,REPLICATION CLIENT'
     state: present
 
-- name: Install mysqld_exporter
+- name: Install mysqld exporter
   include_role:
     name: cloudalchemy.mysqld_exporter
   vars:
     mysqld_exporter_version: "{{ mysql_exporter_version }}"
-    mysqld_exporter_dsn: "{{ mysql_exporter_dsn }}"
-
+    mysqld_exporter_dsn: "{{ mysql_exporter_dsn }}"

--- a/roles/mysqld_exporter/tasks/main.yml
+++ b/roles/mysqld_exporter/tasks/main.yml
@@ -1,5 +1,11 @@
 ---
 
+- name: Check if database password is set
+  assert:
+    that:
+      - mysql_exporter_password | length > 0
+    fail_msg: "You must set the mysql_exporter_password variable"
+
 - name: Create database user with password and PROCESS, REPLICATION CLIENT privileges
   mysql_user:
     name: "{{ mysql_exporter_user }}"


### PR DESCRIPTION
Add prometheus mysqld_exporter role.
Uses exisiting role https://github.com/cloudalchemy/ansible-mysqld_exporter for deploying the exporter.
Additionally to deploying the mysql exporter, the mysql database user for srcaping the metrics is created.