### PR TITLE
Improve authentication protection

### DIFF
--- a/roles/proxy/templates/nginx_artemis.conf.j2
+++ b/roles/proxy/templates/nginx_artemis.conf.j2
@@ -86,7 +86,7 @@ server {
 
     location /api/authenticate {
         proxy_pass http://artemis/api/authenticate;
-        limit_req zone=loginlimit burst=5 nodelay;
+        limit_req zone=loginlimit burst=5 delay=0 rate=1r/s;
     }
 
     location /favicon.ico {

--- a/roles/proxy/templates/nginx_artemis.conf.j2
+++ b/roles/proxy/templates/nginx_artemis.conf.j2
@@ -11,7 +11,7 @@ upstream artemis {
 }
 
 # rate limit for the login REST call, at most 2 requests per second
-limit_req_zone $binary_remote_addr zone=loginlimit:10m rate=5r/s;
+limit_req_zone $binary_remote_addr zone=loginlimit:10m rate=30r/m;
 
 server {
     listen 80 default_server;
@@ -86,7 +86,7 @@ server {
 
     location /api/authenticate {
         proxy_pass http://artemis/api/authenticate;
-        limit_req zone=loginlimit burst=5 delay=0 rate=1r/s;
+        limit_req zone=loginlimit burst=3 delay=2;
     }
 
     location /favicon.ico {

--- a/roles/proxy/templates/nginx_artemis.conf.j2
+++ b/roles/proxy/templates/nginx_artemis.conf.j2
@@ -10,7 +10,7 @@ upstream artemis {
 {% endfor %}
 }
 
-# rate limit for the login REST call, at most 2 requests per second
+# Rate limit for the login REST call, at most one requests per two seconds
 limit_req_zone $binary_remote_addr zone=loginlimit:10m rate=30r/m;
 
 server {
@@ -86,6 +86,12 @@ server {
 
     location /api/authenticate {
         proxy_pass http://artemis/api/authenticate;
+		# For a given violation of the rate limit defined in the zone
+		# * the first 2 (delay) requests will be allowed without delay
+		# * the next (burst - delay) request waits until it fits in the rate limit
+		# * the rest will be denied
+		# If an attacker spams this endpoint, only the first three requests will come through.
+		# This only resets if the violation of the rate limit stops.
         limit_req zone=loginlimit burst=3 delay=2;
     }
 


### PR DESCRIPTION
Prevent bursts from being sent directly, but delay them to fit the requested rate.
Decrease the request rate on this endpoint