### PR TITLE
Add client mount dependency on wireguard interface

### DIFF
--- a/roles/storage_client/templates/mnt-storage.mount.j2
+++ b/roles/storage_client/templates/mnt-storage.mount.j2
@@ -2,7 +2,7 @@
 
 [Unit]
 Description=Artemis Storage Mount
-After=network.target
+After=wg-quick@wg0.service
 
 [Mount]
 What=[{{ storage_server_address }}]:{{ storage_export }}


### PR DESCRIPTION
Since the last cluster network refactoring the NFS share also is exposed in the wireguard network. However, the mount still depended on the general network target, not the wg interface. This caused the mount to fail during boot. With this change, systems waits until the wg network is up and running before mounting the NFS share 