### PR TITLE
Remove nginx version from HTTP response

### DIFF
--- a/roles/proxy/templates/nginx_artemis.conf.j2
+++ b/roles/proxy/templates/nginx_artemis.conf.j2
@@ -10,6 +10,11 @@ upstream artemis {
 {% endfor %}
 }
 
+http {
+	# Remove nginx version from HTTP response
+	server_tokens off;
+}
+
 # Rate limit for the login REST call, at most one requests per two seconds
 limit_req_zone $binary_remote_addr zone=loginlimit:10m rate=30r/m;
 


### PR DESCRIPTION
The intention here is to not expose unnecessary information to a potential attacker.

Removing the information regarding nginx itself is more complex, however, through this repository everyone can already see that we use Nginx so that's not much of a secret.