### PR TITLE
Reload 502-error page after 5 seconds.

### DIFF
--- a/roles/proxy/files/nginx_502.html
+++ b/roles/proxy/files/nginx_502.html
@@ -2,6 +2,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <title>Artemis Maintenance</title>
+<meta http-equiv="refresh" content="5"/>
 <link href="https://fonts.googleapis.com/css?family=Open+Sans:300,400,700" rel="stylesheet">
 <style>
   html, body { padding: 0; margin: 0; width: 100%; height: 100%; }


### PR DESCRIPTION
We got the request that the 502-error page should reload itself (e.g. after 5 seconds) for developers on the test servers, but I would argue that this change also makes sense in the production environment