### PR TITLE
Increase proxy buffering.

### DIFF
--- a/roles/proxy/templates/nginx_artemis.conf.j2
+++ b/roles/proxy/templates/nginx_artemis.conf.j2
@@ -61,6 +61,9 @@ server {
         proxy_read_timeout 900s;
         proxy_max_temp_file_size 0;
         proxy_buffering off;
+        proxy_buffer_size 16k;
+        proxy_buffers 8 16k;
+        proxy_busy_buffers_size 16k;
         fastcgi_send_timeout 900s;
         fastcgi_read_timeout 900s;
         client_max_body_size 128M;

--- a/roles/proxy/templates/nginx_artemis.conf.j2
+++ b/roles/proxy/templates/nginx_artemis.conf.j2
@@ -60,10 +60,10 @@ server {
         proxy_send_timeout 900s;
         proxy_read_timeout 900s;
         proxy_max_temp_file_size 0;
-        proxy_buffering off;
+        proxy_buffering on;
         proxy_buffer_size 16k;
         proxy_buffers 8 16k;
-        proxy_busy_buffers_size 16k;
+        proxy_busy_buffers_size 32k;
         fastcgi_send_timeout 900s;
         fastcgi_read_timeout 900s;
         client_max_body_size 128M;


### PR DESCRIPTION
@manuelmanso is working on the LTI-integration for which large (around 3kb) tokens are sent via Response Headers.

nginx currently does not support these large headers (a limit of 4kb for all headers seems to apply), so we have to increase the buffer size.

The limit of the buffer can still be discussed. Also, I'm not sure why the request is buffered at all, since `proxy_buffering` is set to `off` (EDIT: See this blog post: https://www.nginx.com/blog/avoiding-top-10-nginx-configuration-mistakes/#proxy_buffering-off)