### PR TITLE
Specify broker max memory

### DIFF
--- a/roles/broker/defaults/main.yml
+++ b/roles/broker/defaults/main.yml
@@ -13,6 +13,7 @@ activemq_version: 2.27.0
 activemq_install_directory: /opt/activemq-distribution
 
 activemq_system_ram_proportion: 0.8
+activemq_force_reinstall: false # The broker will not be reinstalled if it already exists, unless this option is set
 
 # configure.yml task
 activemq_working_directory: /opt/broker

--- a/roles/broker/defaults/main.yml
+++ b/roles/broker/defaults/main.yml
@@ -9,8 +9,10 @@ artemis_user_gid: 1337
 jdk_openjdk_version: 16
 
 # broker.yml task
-activemq_version: 2.19.0
+activemq_version: 2.27.0
 activemq_install_directory: /opt/activemq-distribution
+
+activemq_system_ram_proportion: 0.8
 
 # configure.yml task
 activemq_working_directory: /opt/broker

--- a/roles/broker/tasks/configure.yml
+++ b/roles/broker/tasks/configure.yml
@@ -6,7 +6,7 @@
 
 - name: Create broker in {{ activemq_working_directory }} (NOT IDEMPOTENT)
   become: true
-  command: ./artemis create --user {{ activemq_username }} --password {{ activemq_password }} --require-login --force {{ activemq_working_directory }} --java-options "-Xmx{{ (activemq_system_ram_proportion * ansible_memory_mb.real.total) | int }}m"
+  command: ./artemis create --user {{ activemq_username }} --password {{ activemq_password }} --require-login --force {{ activemq_working_directory }} --java-options "-Xms{{ (activemq_system_ram_proportion * ansible_memory_mb.real.total) | int }}m -Xmx{{ (activemq_system_ram_proportion * ansible_memory_mb.real.total) | int }}m"
   args:
     chdir: "{{ activemq_install_directory }}/apache-artemis-{{ activemq_version }}/bin"
   notify: restart broker

--- a/roles/broker/tasks/configure.yml
+++ b/roles/broker/tasks/configure.yml
@@ -10,7 +10,7 @@
   args:
     chdir: "{{ activemq_install_directory }}/apache-artemis-{{ activemq_version }}/bin"
   notify: restart broker
-  when: not broker_install_result.stat.exists
+  when: not broker_install_result.stat.exists or activemq_force_reinstall
 
 - name: Copy primary broker.xml file
   become: true

--- a/roles/broker/tasks/configure.yml
+++ b/roles/broker/tasks/configure.yml
@@ -4,9 +4,9 @@
     path: "{{ activemq_working_directory }}"
   register: broker_install_result
 
-- name: Create broker in {{ activemq_working_directory }} (NOT IDEMPOTENT)
+- name: Create broker in {{ activemq_working_directory }} (NOT IDEMPOTENT)
   become: true
-  command: ./artemis create --user {{ activemq_username }} --password {{ activemq_password }} --require-login --force {{ activemq_working_directory }}
+  command: ./artemis create --user {{ activemq_username }} --password {{ activemq_password }} --require-login --force {{ activemq_working_directory }} --java-options "-Xmx{{ (activemq_system_ram_proportion * ansible_memory_mb.real.total) | int }}m"
   args:
     chdir: "{{ activemq_install_directory }}/apache-artemis-{{ activemq_version }}/bin"
   notify: restart broker


### PR DESCRIPTION
See "Options" at https://activemq.apache.org/components/artemis/documentation/latest/using-server.html:

```
 --java-options <javaOptions>
   Extra java options to be passed to the profile
```


This adds a variable (`activemq_system_ram_proportion`) to set the memory usage to a proportional amount of the available memory.
It also adds an option to force the re-installation of the broker(`activemq_force_reinstall`).


Testing steps:
1. Install the broker using ansible
2. Execute this command: `cat /opt/broker/etc/artemis.profile | grep "Xmx" . -r`
3. The output should be similar to the output here (Notice the Xms and Xmx arguments in the end):
```sleiss@ubunut-home-vm:/opt/broker/etc$ cat /opt/broker/etc/artemis.profile | grep "Xmx" . -r
./artemis.profile:    JAVA_ARGS="-XX:AutoBoxCacheMax=20000 -XX:+PrintClassHistogram -XX:+UseG1GC -XX:+UseStringDeduplication -Xms512M -Xmx2G -Dhawtio.disableProxy=true -Dhawtio.realm=activemq -Dhawtio.offline=true -Dhawtio.rolePrincipalClasses=org.apache.activemq.artemis.spi.core.security.jaas.RolePrincipal -Djolokia.policyLocation=${ARTEMIS_INSTANCE_ETC_URI}jolokia-access.xml -Xms195m -Xmx195m"
```
