### PR TITLE
Add support for databases other than MySQL

### DIFF
--- a/roles/artemis/defaults/main.yml
+++ b/roles/artemis/defaults/main.yml
@@ -68,16 +68,15 @@ artemis_war_url: "https://github.com/ls1intum/Artemis/releases/download/{{ artem
 
 artemis_system_ram_proportion: 0.8  # How much % of the system RAM to allocate to the Artemis service (Default here: 80%)
 
-artemis_database_schema: mysql
-artemis_database_type: MYSQL
-artemis_database_platform: org.hibernate.dialect.MySQL8Dialect
+artemis_database_type: mysql # The type of the database used. Used in the JDBC URL and as uppercase for the JPA database type (Default of Artemis is currently mysql/MYSQL)
+artemis_database_platform: org.hibernate.dialect.MySQL8Dialect # The Hibernate dialect class to use (Default for Artemis is currently org.hibernate.dialect.MySQL8Dialect)
 artemis_database_host: localhost
-artemis_database_port: 3306
+artemis_database_port: 3306 # The port that the database is reachable on (MySQL default: 3306)
 artemis_database_dbname: artemis
 artemis_database_username: artemis
 artemis_database_password: #FIXME
-artemis_database_encoding: utf8mb4
-artemis_database_collation: utf8mb4_unicode_ci
+artemis_database_encoding: utf8mb4 # MySQL specific default encoding
+artemis_database_collation: utf8mb4_unicode_ci # MySQL specific default collation
 
 artemis_encryption_password: #FIXME
 artemis_bcrypt_salt_rounds: 11

--- a/roles/artemis/defaults/main.yml
+++ b/roles/artemis/defaults/main.yml
@@ -68,7 +68,11 @@ artemis_war_url: "https://github.com/ls1intum/Artemis/releases/download/{{ artem
 
 artemis_system_ram_proportion: 0.8  # How much % of the system RAM to allocate to the Artemis service (Default here: 80%)
 
+artemis_database_schema: mysql
+artemis_database_type: MYSQL
+artemis_database_platform: org.hibernate.dialect.MySQL8Dialect
 artemis_database_host: localhost
+artemis_database_port: 3306
 artemis_database_dbname: artemis
 artemis_database_username: artemis
 artemis_database_password: #FIXME

--- a/roles/artemis/templates/application-prod.yml.j2
+++ b/roles/artemis/templates/application-prod.yml.j2
@@ -3,7 +3,7 @@
 spring:
   datasource:
     type: com.zaxxer.hikari.HikariDataSource
-    url: jdbc:{{ artemis_database_schema }}://{{ artemis_database_host }}:{{ artemis_database_port }}/{{ artemis_database_dbname }}?createDatabaseIfNotExist=true&useUnicode=true&characterEncoding=utf8&allowPublicKeyRetrieval=true&useSSL=false&useLegacyDatetimeCode=false&serverTimezone=UTC
+    url: jdbc:{{ artemis_database_type }}://{{ artemis_database_host }}:{{ artemis_database_port }}/{{ artemis_database_dbname }}?createDatabaseIfNotExist=true&useUnicode=true&characterEncoding=utf8&allowPublicKeyRetrieval=true&useSSL=false&useLegacyDatetimeCode=false&serverTimezone=UTC
     username: {{ artemis_database_username }}
     password: {{ artemis_database_password }}
     hikari:
@@ -17,7 +17,7 @@ spring:
         useServerPrepStmts: true
   jpa:
     database-platform: {{ artemis_database_platform }}
-    database: {{ artemis_database_type }}
+    database: {{ artemis_database_type|upper }}
     hibernate:
       connection:
         charSet: {{ artemis_database_encoding }}

--- a/roles/artemis/templates/application-prod.yml.j2
+++ b/roles/artemis/templates/application-prod.yml.j2
@@ -3,7 +3,7 @@
 spring:
   datasource:
     type: com.zaxxer.hikari.HikariDataSource
-    url: jdbc:mysql://{{ artemis_database_host }}:3306/{{ artemis_database_dbname }}?createDatabaseIfNotExist=true&useUnicode=true&characterEncoding=utf8&allowPublicKeyRetrieval=true&useSSL=false&useLegacyDatetimeCode=false&serverTimezone=UTC
+    url: jdbc:{{ artemis_database_schema }}://{{ artemis_database_host }}:{{ artemis_database_port }}/{{ artemis_database_dbname }}?createDatabaseIfNotExist=true&useUnicode=true&characterEncoding=utf8&allowPublicKeyRetrieval=true&useSSL=false&useLegacyDatetimeCode=false&serverTimezone=UTC
     username: {{ artemis_database_username }}
     password: {{ artemis_database_password }}
     hikari:
@@ -16,6 +16,8 @@ spring:
         prepStmtCacheSqlLimit: 2048
         useServerPrepStmts: true
   jpa:
+    database-platform: {{ artemis_database_platform }}
+    database: {{ artemis_database_type }}
     hibernate:
       connection:
         charSet: {{ artemis_database_encoding }}


### PR DESCRIPTION
## Motivation
Currently, the appliction.yml template is hardcoded to use MySQL. 
Since Artemis will soon support at least PostgreSQL, this has to be configurable, so we can set up a new test server.

## Changes
For this, I added 4 new variables to specify the database types for JDBC and JPA and added them to the template. The default values for these are the previously hardcoded values or the default values from the Artemis repository.

## Example
Supporting PostgreSQL is now as trivial by setting the new values to:
```
artemis_database_schema: postgresql
artemis_database_type: POSTGRESQL
artemis_database_platform: org.hibernate.dialect.PostgreSQL10Dialect
artemis_database_port: 5432
```