### PR TITLE
Add properties introduced for the data export 

### DIFF
--- a/roles/artemis/defaults/main.yml
+++ b/roles/artemis/defaults/main.yml
@@ -56,6 +56,11 @@ artemis_working_directory: "/opt/artemis"
 artemis_repo_basepath: "."
 
 artemis_legal_path: /opt/artemis/legal
+artemis_data_export_path: /opt/artemis/data-exports
+# the following two values must be cron expressions
+artemis_scheduling_data_export_creation_time: 0 0 4 * * * # every day at 4 am
+artemis_scheduling_programming_exercises_cleanup_time: 0 0 3 * * * # every day at 3 am
+artemis_data_export_days_between_data_exports: 14
 
 artemis_ssh_key_path: /opt/keys
 artemis_ssh_key_name: "artemis_ssh_key"

--- a/roles/artemis/defaults/main.yml
+++ b/roles/artemis/defaults/main.yml
@@ -57,9 +57,11 @@ artemis_repo_basepath: "."
 
 artemis_legal_path: /opt/artemis/legal
 artemis_data_export_path: /opt/artemis/data-exports
+
 # the following two values must be cron expressions
 artemis_scheduling_data_export_creation_time: 0 0 4 * * * # every day at 4 am
 artemis_scheduling_programming_exercises_cleanup_time: 0 0 3 * * * # every day at 3 am
+
 artemis_data_export_days_between_data_exports: 14
 
 artemis_ssh_key_path: /opt/keys

--- a/roles/artemis/templates/application-prod.yml.j2
+++ b/roles/artemis/templates/application-prod.yml.j2
@@ -71,6 +71,7 @@ artemis:
   file-upload-path: {{ artemis_repo_basepath }}/uploads
   submission-export-path: {{ artemis_repo_basepath }}/exports
   legal-path: {{ artemis_legal_path }}
+  data-export-path: {{ artemis_data_export_path }}
   bcrypt-salt-rounds: {{ artemis_bcrypt_salt_rounds }}
   user-management:
 {% if user_management.jira is defined and user_management.jira is not none %}
@@ -196,6 +197,11 @@ artemis:
   apollon:
     conversion-service-url: {{ apollon_url }}
 {% endif %}
+  scheduling:
+    data-export-creation-time: {{ artemis_scheduling_data_export_creation_time }}
+    programming-exercises-cleanup-time: {{ artemis_scheduling_programming_exercises_cleanup_time }}
+  data-export:
+    days-between-data-exports: {{ artemis_data_export_days_between_data_exports }}
 
 jhipster:
 

--- a/roles/artemis/templates/artemis.env.j2
+++ b/roles/artemis/templates/artemis.env.j2
@@ -49,7 +49,7 @@ ARTEMIS_REPODOWNLOADCLONEPATH='{{ artemis_repo_basepath }}/repos-download'
 ARTEMIS_FILEUPLOADPATH='{{ artemis_repo_basepath }}/uploads'
 ARTEMIS_SUBMISSIONEXPORTPATH='{{ artemis_repo_basepath }}/exports'
 ARTEMIS_LEGALPATH='{{ artemis_legal_path }}'
-ARTEMIS_DATAEXPORTPATH ='{{ artemis_data_export_path }}'
+ARTEMIS_DATAEXPORTPATH='{{ artemis_data_export_path }}'
 ARTEMIS_BCRYPTSALTROUNDS='{{ artemis_bcrypt_salt_rounds }}'
 {% if user_management.jira is defined and user_management.jira is not none %}
 ARTEMIS_USERMANAGEMENT_USEEXTERNAL='true'

--- a/roles/artemis/templates/artemis.env.j2
+++ b/roles/artemis/templates/artemis.env.j2
@@ -49,6 +49,7 @@ ARTEMIS_REPODOWNLOADCLONEPATH='{{ artemis_repo_basepath }}/repos-download'
 ARTEMIS_FILEUPLOADPATH='{{ artemis_repo_basepath }}/uploads'
 ARTEMIS_SUBMISSIONEXPORTPATH='{{ artemis_repo_basepath }}/exports'
 ARTEMIS_LEGALPATH='{{ artemis_legal_path }}'
+ARTEMIS_DATAEXPORTPATH ='{{ artemis_data_export_path }}'
 ARTEMIS_BCRYPTSALTROUNDS='{{ artemis_bcrypt_salt_rounds }}'
 {% if user_management.jira is defined and user_management.jira is not none %}
 ARTEMIS_USERMANAGEMENT_USEEXTERNAL='true'
@@ -146,6 +147,9 @@ ARTEMIS_ATHENE_TOKENVALIDITYINSECONDS='10800'
 {% if apollon_url is defined %}
 ARTEMIS_APOLLON_CONVERSIONSERVICEURL='{{ apollon_url }}'
 {% endif %}
+ARTEMIS_SCHEDULING_DATAEXPORTCREATIONTIME = '{{ artemis_scheduling_data_export_creation_time }}'
+ARTEMIS_SCHEDULING_PROGRAMMINGEXERCISESCLEANUPTIME = '{{ artemis_scheduling_programming_exercises_cleanup_time }}'
+ARTEMIS_DATAEXPORT_DAYSBETWEENDATAEXPORTS = '{{ artemis_data_export_days_between_data_exports }}'
 {% if is_multinode_install|bool == true and artemis_jhipster_jwt is not none and artemis_jhipster_registry_password is not none  %}
 JHIPSTER_SECURITY_AUTHENTICATION_JWT_BASE64SECRET='{{ artemis_jhipster_jwt }}'
 JHIPSTER_SECURITY_AUTHENTICATION_JWT_TOKENVALIDITYINSECONDS='259200'

--- a/roles/artemis/templates/docker.env.j2
+++ b/roles/artemis/templates/docker.env.j2
@@ -3,6 +3,7 @@ ARTEMIS_SSH_KEY_PATH='{{ artemis_ssh_key_path }}'
 ARTEMIS_ENV_FILE='{{ artemis_working_directory }}/artemis.env'
 ARTEMIS_VOLUME_MOUNT='{{ artemis_working_directory }}/data/artemis'
 ARTEMIS_LEGAL_MOUNT='{{ artemis_working_directory }}/legal'
+ARTEMIS_DATA_EXPORT_MOUNT='{{ artemis_working_directory }}/data-exports'
 
 DATABASE_ENV_FILE='{{ artemis_working_directory }}/database.env'
 DATABASE_VOLUME_MOUNT='{{ artemis_working_directory }}/data/database'


### PR DESCRIPTION
These PRs
https://github.com/ls1intum/Artemis/pull/6500
https://github.com/ls1intum/Artemis/pull/6670 introduce the following properties:
| Property | Value |Comment|
|----------|-------|------------|
|artemis.data-export-path| opt/artemis/data-export| not really sure if this is correct, I just used the legal-path property as a template
|artemis.data-export-days-between-data-exports |  14 |
|artemis.scheduling.programming-exercises-cleanup-time | 0 0 3 * * * |Cron expression
|artemis.scheduling.data-export-creation-time| 0 0 4 * * *|Cron expression