### PR TITLE
Remove special Athene endpoints

### DIFF
--- a/roles/proxy/defaults/main.yml
+++ b/roles/proxy/defaults/main.yml
@@ -26,7 +26,7 @@ proxy_worker_rlmmiit_nofile: 30000
 proxy_worker_connections: 20000
 proxy_server_names_hash_bucket_size: 256
 
-proxy_primary_node_url: "{{ proxy_available_nodes[0] }}"
+proxy_primary_node_url:
 
 proxy_site_template: artemis
 

--- a/roles/proxy/defaults/main.yml
+++ b/roles/proxy/defaults/main.yml
@@ -26,7 +26,6 @@ proxy_worker_rlmmiit_nofile: 30000
 proxy_worker_connections: 20000
 proxy_server_names_hash_bucket_size: 256
 
-
 proxy_site_template: artemis
 
 proxy_generate_dh_param: true

--- a/roles/proxy/defaults/main.yml
+++ b/roles/proxy/defaults/main.yml
@@ -26,7 +26,7 @@ proxy_worker_rlmmiit_nofile: 30000
 proxy_worker_connections: 20000
 proxy_server_names_hash_bucket_size: 256
 
-proxy_primary_node_url:
+proxy_primary_node_url: "{{ proxy_available_nodes[0] }}"
 
 proxy_site_template: artemis
 

--- a/roles/proxy/defaults/main.yml
+++ b/roles/proxy/defaults/main.yml
@@ -26,7 +26,6 @@ proxy_worker_rlmmiit_nofile: 30000
 proxy_worker_connections: 20000
 proxy_server_names_hash_bucket_size: 256
 
-proxy_primary_node_url:
 
 proxy_site_template: artemis
 

--- a/roles/proxy/defaults/main.yml
+++ b/roles/proxy/defaults/main.yml
@@ -26,7 +26,6 @@ proxy_worker_rlmmiit_nofile: 30000
 proxy_worker_connections: 20000
 proxy_server_names_hash_bucket_size: 256
 
-proxy_athene_baseurl:
 proxy_primary_node_url:
 
 proxy_site_template: artemis

--- a/roles/proxy/templates/nginx_artemis.conf.j2
+++ b/roles/proxy/templates/nginx_artemis.conf.j2
@@ -77,13 +77,6 @@ server {
 {% endif %}
 
 {% if proxy_athene_baseurl is not none %}
-    location /athene-tracking {
-        proxy_pass {{ proxy_athene_baseurl }}/tracking;
-        proxy_set_header Host $host;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
-    }
-
     location /api/athene-result/ {
         proxy_pass {{ proxy_primary_node_url }}/api/athene-result/;
         client_max_body_size 2g;

--- a/roles/proxy/templates/nginx_artemis.conf.j2
+++ b/roles/proxy/templates/nginx_artemis.conf.j2
@@ -76,11 +76,6 @@ server {
     }
 {% endif %}
 
-    location /api/athene-result/ {
-        proxy_pass {{ proxy_primary_node_url }}/api/athene-result/;
-        client_max_body_size 2g;
-    }
-
     location /api/authenticate {
         proxy_pass http://artemis/api/authenticate;
 		# For a given violation of the rate limit defined in the zone

--- a/roles/proxy/templates/nginx_artemis.conf.j2
+++ b/roles/proxy/templates/nginx_artemis.conf.j2
@@ -76,12 +76,10 @@ server {
     }
 {% endif %}
 
-{% if proxy_athene_baseurl is not none %}
     location /api/athene-result/ {
         proxy_pass {{ proxy_primary_node_url }}/api/athene-result/;
         client_max_body_size 2g;
     }
-{% endif %}
 
     location /api/authenticate {
         proxy_pass http://artemis/api/authenticate;


### PR DESCRIPTION
Related PR: https://github.com/ls1intum/Artemis/pull/6764

The linked PR removes an unused tracking functionality of Athene. This tracking needed its own Nginx endpoint, which this PR now removes from the ansible configuration.

**Update:** We also removed the `/athene-result` endpoint (which previously increased the max upload size) because the increased limit will not be necessary for future working versions, and there is no current working version of Athene anyways.