### PR TITLE
`Bugfix`: Fix empty ssh key path property for Gitlab

### DIFF
--- a/roles/artemis/templates/application-prod.yml.j2
+++ b/roles/artemis/templates/application-prod.yml.j2
@@ -137,7 +137,9 @@ artemis:
     health-api-token: {{ version_control.gitlab.health_api_token }}
     ssh-template-clone-url: {{ version_control.gitlab.ssh_url }}
     ssh-keys-url-path: /-/profile/keys
+{% if artemis_ssh_key_path is defined and artemis_ssh_key_path is not none and artemis_ssh_key_path != "" %}
     ssh-private-key-folder-path:  {{ artemis_ssh_key_path }}
+{% endif %}
 {% if artemis_ssh_key_password is defined and artemis_ssh_key_password is not none %}
     ssh-private-key-password: {{ artemis_ssh_key_password }}
 {% endif %}

--- a/roles/artemis/templates/artemis.env.j2
+++ b/roles/artemis/templates/artemis.env.j2
@@ -110,7 +110,9 @@ ARTEMIS_VERSIONCONTROL_CITOKEN='{{ version_control.gitlab.ci_token }}'
 ARTEMIS_VERSIONCONTROL_HEALTHAPITOKEN='{{ version_control.gitlab.health_api_token }}'
 ARTEMIS_VERSIONCONTROL_SSHTEMPLATECLONEURL='{{ version_control.gitlab.ssh_url }}'
 ARTEMIS_VERSIONCONTROL_SSHKEYSURLPATH='/-/profile/keys'
+{% if artemis_ssh_key_path is defined and artemis_ssh_key_path is not none and artemis_ssh_key_path != "" %}
 ARTEMIS_VERSIONCONTROL_SSHPRIVATEKEYFOLDERPATH='{{ artemis_ssh_key_path }}'
+{% endif %}
 ARTEMIS_VERSIONCONTROL_DEFAULTBRANCH='main'
 ARTEMIS_VERSIONCONTROL_VERSIONCONTROLACCESSTOKEN='true'
 {% if artemis_ssh_key_password is defined and artemis_ssh_key_password is not none %}


### PR DESCRIPTION
There was an issue where the `ssh-private-key-folder-path` was not excluded for Gitlab setups when the `artemis_ssh_key_path` was empty. This broke communication with Gitlab, as Artemis tried to use non-existent ssh keys for authentication.
This PR adds the same if check that was already used for BitBucket setups to the Gitlab setup.