### PR TITLE
Update Athena configuration to use only a secret

### DIFF
--- a/roles/artemis/templates/application-prod.yml.j2
+++ b/roles/artemis/templates/application-prod.yml.j2
@@ -191,8 +191,7 @@ artemis:
 {% if athena is defined %}
   athena:
     url: {{ athena.url }}
-    base64-secret: {{ athena.secret }}
-    token-validity-in-seconds: 10800
+    secret: {{ athena.secret }}
 {% endif %}
 
 {% if apollon_url is defined %}

--- a/roles/artemis/templates/artemis.env.j2
+++ b/roles/artemis/templates/artemis.env.j2
@@ -143,8 +143,7 @@ ARTEMIS_GIT_NAME='artemis'
 ARTEMIS_GIT_EMAIL='{{ artemis_email }}'
 {% if athena is defined %}
 ARTEMIS_ATHENA_URL='{{ athena.url }}'
-ARTEMIS_ATHENA_BASE64SECRET='{{ athena.secret }}'
-ARTEMIS_ATHENA_TOKENVALIDITYINSECONDS='10800'
+ARTEMIS_ATHENA_SECRET='{{ athena.secret }}'
 {% endif %}
 {% if apollon_url is defined %}
 ARTEMIS_APOLLON_CONVERSIONSERVICEURL='{{ apollon_url }}'


### PR DESCRIPTION
https://github.com/ls1intum/Artemis/pull/6861 was recently merged. 

Among other things, it changes the name of the secret for the communication with Athena from `base64-secret` to `secret` to reflect that it does not have to be base64-encoded.

I also removed the `token-validity-in-seconds` parameter because it's not used anywhere. [According to @jpbernius](https://github.com/ls1intum/Artemis/pull/6861#discussion_r1279733364), it was previously used for tracking functionality for research purposes.