### PR TITLE
Add Athena config for chosen modules

### DIFF
--- a/roles/artemis/README.md
+++ b/roles/artemis/README.md
@@ -111,6 +111,9 @@ Athena configuration:
 athena:
   url:
   secret:
+  modules:
+    text: module_text_cofee
+    programming: module_programming_themisml
 ```
 ---
 

--- a/roles/artemis/README.md
+++ b/roles/artemis/README.md
@@ -112,8 +112,8 @@ athena:
   url:
   secret:
   modules:
-    text: module_text_cofee
-    programming: module_programming_themisml
+    text: # e.g. module_text_cofee or module_text_llm
+    programming: # e.g. module_programming_themisml or module_programming_llm
 ```
 ---
 

--- a/roles/artemis/defaults/main.yml
+++ b/roles/artemis/defaults/main.yml
@@ -151,6 +151,9 @@ artemis_external_password_reset_link_de: "https://campus.tum.de/tumonline/ee/ui/
   #athena:
   #  url:
   #  secret:
+  #  modules:
+  #    text: module_text_cofee
+  #    programming: module_programming_themisml
   #
   #
   #lti:

--- a/roles/artemis/defaults/main.yml
+++ b/roles/artemis/defaults/main.yml
@@ -152,8 +152,8 @@ artemis_external_password_reset_link_de: "https://campus.tum.de/tumonline/ee/ui/
   #  url:
   #  secret:
   #  modules:
-  #    text: module_text_cofee
-  #    programming: module_programming_themisml
+  #    text:
+  #    programming:
   #
   #
   #lti:

--- a/roles/artemis/templates/application-prod.yml.j2
+++ b/roles/artemis/templates/application-prod.yml.j2
@@ -192,6 +192,9 @@ artemis:
   athena:
     url: {{ athena.url }}
     secret: {{ athena.secret }}
+    modules:
+      text: {{ athena.modules.text }}
+      programming: {{ athena.modules.programming }}
 {% endif %}
 
 {% if apollon_url is defined %}


### PR DESCRIPTION
This PR introduces new Athena configuration for modules:
https://github.com/ls1intum/Artemis/pull/7136

This PR introduces the same configuration in Ansible as well.

The configuration is used to choose the assessment module used to generate Athena feedback suggestions. There are multiple approaches available. The configuration entry allows admins to choose which suggestion generation approach Athena takes.