### PR TITLE
`Development`: Fix usage of multi-node variable if unset

### DIFF
--- a/roles/artemis/templates/artemis-docker.sh.j2
+++ b/roles/artemis/templates/artemis-docker.sh.j2
@@ -5,7 +5,7 @@ PROJECT_DIR="{{ artemis_working_directory }}/Artemis/docker"
 {% set localci_compose_file = "test-server-" + artemis_database_type + "-localci.yml" %}
 {% set multi_node_localci_compose_file = "test-server-multi-node-" + artemis_database_type + "-localci.yml" %}
 
-COMPOSE_FILE="{% if continuous_integration.localci is defined and is_multinode_install is defined %}{{ multi_node_localci_compose_file }}{% elif continuous_integration.localci is defined %}{{ localci_compose_file }}{% else %}{{ default_compose_file }}{% endif %}"
+COMPOSE_FILE="{% if continuous_integration.localci is defined and is_multinode_install is defined and is_multinode_install %}{{ multi_node_localci_compose_file }}{% elif continuous_integration.localci is defined %}{{ localci_compose_file }}{% else %}{{ default_compose_file }}{% endif %}"
 ENV_FILE="{{ artemis_working_directory }}/docker.env"
 {% if continuous_integration.localci is defined %}
 export DOCKER_GROUP_ID=$(getent group docker | cut -d: -f3)

--- a/roles/artemis/templates/docker.env.j2
+++ b/roles/artemis/templates/docker.env.j2
@@ -16,9 +16,11 @@ DATABASE_ENV_FILE='{{ artemis_working_directory }}/database.env'
 DATABASE_VOLUME_MOUNT='{{ artemis_working_directory }}/data/database'
 
 # Broker & Registry vars
+{% if is_multinode_install %}
 REGISTRY_PASSWORD='{{ artemis_jhipster_registry_password }}'
 BROKER_USER='{{ broker.username }}'
 BROKER_PASSWORD='{{ broker.password }}'
+{% endif %}
 
 # Nginx vars
 NGINX_PROXY_SSL_CERTIFICATE_PATH='{{ proxy_ssl_certificate_path }}'


### PR DESCRIPTION
For a simple and straightforward deployment `is_multinode_install` and `broker` is unset.

`broker` should only be used, if `is_multinode_install` is set.

If `is_multinode_install` is set to `false` it should not include the multi-node information. So it is not sufficient to check if the value is defined.