### PR TITLE
Adapt Athena config and readme to latest changes allowing an individual module selection per exercise

### DIFF
--- a/roles/artemis/README.md
+++ b/roles/artemis/README.md
@@ -115,9 +115,7 @@ Athena configuration:
 athena:
   url:
   secret:
-  modules:
-    text: # e.g. module_text_cofee or module_text_llm
-    programming: # e.g. module_programming_themisml or module_programming_llm
+  restricted-modules: # optional parameter to restrict access to specific modules, e.g. module_text_llm,module_programming_llm
 ```
 ---
 

--- a/roles/artemis/templates/application-prod.yml.j2
+++ b/roles/artemis/templates/application-prod.yml.j2
@@ -203,9 +203,7 @@ artemis:
   athena:
     url: {{ athena.url }}
     secret: {{ athena.secret }}
-    modules:
-      text: {{ athena.modules.text }}
-      programming: {{ athena.modules.programming }}
+    restricted-modules: {{ athena.restricted-modules }}
 {% endif %}
 
 {% if apollon_url is defined %}


### PR DESCRIPTION
This Artemis PR changes the Athena configuration for modules:
https://github.com/ls1intum/Artemis/pull/7809

This PR adapts the same configuration in Ansible as well.

With the restricted modules options, Athena feedback suggestion modules (e.g. modules that cost money per usage such as LLM Modules) can be made available only to courses that are allowed to access them.