### PR TITLE
`Bugix`: Fix fail condition when docker is not installed

### DIFF
--- a/roles/artemis/tasks/node_checks.yml
+++ b/roles/artemis/tasks/node_checks.yml
@@ -8,4 +8,4 @@
 - name: Fail if docker is not installed
   ansible.builtin.fail:
     msg: "Docker is not installed - please install docker before running this role."
-  when: docker_installed.stat.exists
+  when: not docker_installed.stat.exists


### PR DESCRIPTION
The execution should fail if docker is _not_ installed.