### PR TITLE
`Artemis`: Update prometheus metrics setting to match Artemis

### DIFF
--- a/roles/artemis/templates/application-prod.yml.j2
+++ b/roles/artemis/templates/application-prod.yml.j2
@@ -334,8 +334,8 @@ logging:
     name: '{{ artemis_working_directory }}/artemis.log'
 
 management:
-  metrics:
-    export:
-      prometheus:
+  prometheus:
+    metrics:
+      export:
         enabled: true
 

--- a/roles/artemis/templates/artemis.env.j2
+++ b/roles/artemis/templates/artemis.env.j2
@@ -240,4 +240,4 @@ EUREKA_INSTANCE_INSTANCEID='Artemis:{{ artemis_eureka_instance_id }}'
 {% endif %}
 {% endif %}
 LOGGING_FILE_NAME='{{ artemis_working_directory }}/artemis.log'
-MANAGEMENT_METRICS_EXPORT_PROMETHEUS_ENABLED='true'
+MANAGEMENT_PROMETHEUS_METRICS_EXPORT_ENABLED='true'


### PR DESCRIPTION
This setting was changed with the Spring Boot 3 update in Artemis 7.0.0, so we need to update it here as well.