### PR TITLE
`Artemis`: Switch to JDK 21

### DIFF
--- a/roles/artemis/defaults/main.yml
+++ b/roles/artemis/defaults/main.yml
@@ -37,7 +37,7 @@ artemis_deployment_user_comment: "User to deploy artemis to this host"
 # Java Setup
 ##############################################################################
 
-openjdk_version: 17
+openjdk_version: 21
 
 
 ##############################################################################
@@ -232,6 +232,8 @@ artemis_eureka_instance_id: "{{ node_id }}"
 # Auto-generated Variables - No not alter!
 ##############################################################################
 
+artemis_computed_is_core_node: "{{ not (continuous_integration.localci is defined and continuous_integration.localci is not none) or (continuous_integration.localci.is_core_node is defined and continuous_integration.localci.is_core_node) }}"
+
 # Compute Spring Profiles from set variables
 artemis_spring_profile_env: "prod"
 artemis_spring_profile_user_management: "{% if user_management.jira is defined and user_management.jira is not none %},jira{% endif %}" # none HAS to be lowercase ¯\_(ツ)_/¯
@@ -246,7 +248,7 @@ artemis_spring_profile_iris: "{% if iris is defined and iris is not none %},iris
 artemis_spring_profile_aeolus: "{% if aeolus is defined and aeolus is not none %},aeolus{% endif %}"
 artemis_spring_profile_lti: "{% if lti.oauth_secret is defined and lti.oauth_secret is not none %},lti{% endif %}"
 
-artemis_spring_profile_core: "{% if not (continuous_integration.localci is defined and continuous_integration.localci is not none) or (continuous_integration.localci.is_core_node is defined and continuous_integration.localci.is_core_node) %},core{{ artemis_spring_profile_user_management }}{{ artemis_spring_profile_ldap }}{{ artemis_spring_profile_version_control }}{{ artemis_spring_profile_continuous_integration }}{{ artemis_spring_profile_athena }}{{ artemis_spring_profile_scheduling }}{{ artemis_spring_profile_docker }}{{ artemis_spring_profile_iris }}{{ artemis_spring_profile_aeolus }}{{ artemis_spring_profile_lti }}{% endif %}"
+artemis_spring_profile_core: "{% if artemis_computed_is_core_node %},core{{ artemis_spring_profile_user_management }}{{ artemis_spring_profile_ldap }}{{ artemis_spring_profile_version_control }}{{ artemis_spring_profile_continuous_integration }}{{ artemis_spring_profile_athena }}{{ artemis_spring_profile_scheduling }}{{ artemis_spring_profile_docker }}{{ artemis_spring_profile_iris }}{{ artemis_spring_profile_aeolus }}{{ artemis_spring_profile_lti }}{% endif %}"
 artemis_spring_profile_buildagent: "{% if continuous_integration.localci is defined and continuous_integration.localci is not none %}{% if continuous_integration.localci.is_build_agent is defined and continuous_integration.localci.is_build_agent is not none and continuous_integration.localci.is_build_agent %},buildagent{% endif %}{% endif %}"
 
 artemis_spring_profiles: "{{ artemis_spring_profile_env }}{{ artemis_spring_profile_buildagent }}{{ artemis_spring_profile_core }}"

--- a/roles/artemis/templates/application-prod.yml.j2
+++ b/roles/artemis/templates/application-prod.yml.j2
@@ -182,8 +182,8 @@ artemis:
     url: {{ version_control.localvc.url }}
     local-vcs-repo-path: {{ version_control.localvc.repo_storage_base_path }}
     default-branch: {{ artemis_version_control_default_branch_name }}
-    user: {{ version_control.localvc.user }}
-    password: {{ version_control.localvc.password }}
+    user: {{ artemis_internal_admin_user }}
+    password: {{ artemis_internal_admin_password }}
 {% endif %}
 
 {% if continuous_integration.bamboo is defined %}

--- a/roles/artemis/templates/application-prod.yml.j2
+++ b/roles/artemis/templates/application-prod.yml.j2
@@ -1,6 +1,7 @@
 {{ ansible_managed | comment }}
 
 spring:
+{% if artemis_computed_is_core_node %}
   datasource:
     type: com.zaxxer.hikari.HikariDataSource
     url: jdbc:{{ artemis_database_type }}://{{ artemis_database_host }}:{{ artemis_database_port }}/{{ artemis_database_dbname }}?createDatabaseIfNotExist=true&useUnicode=true&characterEncoding=utf8&allowPublicKeyRetrieval=true&useSSL=false&useLegacyDatetimeCode=false&serverTimezone=UTC
@@ -30,11 +31,13 @@ spring:
       password: {{ broker.password }}
       addresses: "{{ broker.url }}:61613"
 {% endif %}
+{% endif %}
 {% if is_multinode_install and hazelcast_address is defined %}
   hazelcast:
     interface: "{{ hazelcast_address }}"
 {% endif %}
 
+{% if artemis_computed_is_core_node %}
 {% if shared_monitoring_host_v4 is not none %}
   prometheus:
     monitoringIp: "{{ shared_monitoring_host_v4 }}"
@@ -55,6 +58,26 @@ spring:
       ssl:
         trust: {{ mail.ssl_trust }}
 {% endif %}
+{% else %}
+  liquibase:
+      enabled: false #not needed for build agents
+  autoconfigure:
+      exclude:
+          # Hibernate and DataSource are not needed in the build agent
+          - org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfiguration
+          - org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration
+          # Those metrics are repeated here, because overriding the `exclude` array is not possible
+          - org.springframework.boot.actuate.autoconfigure.metrics.data.RepositoryMetricsAutoConfiguration
+          - org.springframework.boot.actuate.autoconfigure.metrics.jdbc.DataSourcePoolMetricsAutoConfiguration
+          - org.springframework.boot.actuate.autoconfigure.metrics.startup.StartupTimeMetricsListenerAutoConfiguration
+          - org.springframework.boot.actuate.autoconfigure.metrics.task.TaskExecutorMetricsAutoConfiguration
+          - org.springframework.boot.actuate.autoconfigure.metrics.web.tomcat.TomcatMetricsAutoConfiguration
+  cloud:
+      loadbalancer:
+          cache:
+              enabled: false #not needed for build agents
+{% endif %}
+
 
 server:
   port: {{ artemis_server_port }}
@@ -65,6 +88,7 @@ server:
       internal-proxies: 10\.\d{1,3}\.\d{1,3}\.\d{1,3}|192\.168\.\d{1,3}\.\d{1,3}|169\.254\.\d{1,3}\.\d{1,3}|127\.\d{1,3}\.\d{1,3}\.\d{1,3}|172\.1[6-9]{1}\.\d{1,3}\.\d{1,3}|172\.2[0-9]{1}\.\d{1,3}\.\d{1,3}|172\.3[0-1]{1}\.\d{1,3}\.\d{1,3}|0:0:0:0:0:0:0:1|::1|fcfe::f:1|fcfe:0:0:0:0:0:f:1
 
 artemis:
+{% if artemis_computed_is_core_node %}
   course-archives-path: {{ artemis_repo_basepath }}/course-archives
   repo-clone-path: {{ artemis_repo_basepath }}/repos
   repo-download-clone-path: {{ artemis_repo_basepath }}/repos-download
@@ -115,6 +139,7 @@ artemis:
 {% endif %}
     login:
       account-name: {{ artemis_account_login_info }}
+{% endif %}
 {% if version_control.bitbucket is defined %}
   version-control:
     url: {{ version_control.bitbucket.url }}
@@ -211,6 +236,11 @@ artemis:
 {% endif %}
 {% endif %}
 
+  git:
+    name: artemis
+    email: {{ artemis_email }}
+
+{% if artemis_computed_is_core_node %}
 {% if lti is defined %}
   lti:
     id: artemis_lti
@@ -221,10 +251,6 @@ artemis:
     user-group-name-edx: edx
     user-group-name-u4i: u4i
 {% endif %}
-
-  git:
-    name: artemis
-    email: {{ artemis_email }}
 
 {% if athena is defined %}
   athena:
@@ -257,6 +283,7 @@ artemis:
     event-logging:
       enable: {{ enable_science_event_logging | lower }}
 {% endif %}
+{% endif %}
 
 {% if aeolus.url is defined and aeolus.url is not none %}
 aeolus:
@@ -286,6 +313,7 @@ jhipster:
     base-url: {{ artemis_server_url }}
     from: '{{artemis_notification_from}} <{{ artemis_email.split("@")[0] }}+notification@{{ artemis_email.split("@")[1] }}>'
 
+{% if artemis_computed_is_core_node %}
 # Properties to be exposed on the /info management endpoint
 info:
   guided-tour:
@@ -313,6 +341,7 @@ info:
   post-hog:
     host: {{ post_hog.host }}
     token: {{ post_hog.token }}
+{% endif %}
 {% endif %}
 
 {% if is_multinode_install and artemis_eureka_urls is defined and hazelcast_address is defined %}

--- a/roles/artemis/templates/application-prod.yml.j2
+++ b/roles/artemis/templates/application-prod.yml.j2
@@ -72,10 +72,6 @@ spring:
           - org.springframework.boot.actuate.autoconfigure.metrics.startup.StartupTimeMetricsListenerAutoConfiguration
           - org.springframework.boot.actuate.autoconfigure.metrics.task.TaskExecutorMetricsAutoConfiguration
           - org.springframework.boot.actuate.autoconfigure.metrics.web.tomcat.TomcatMetricsAutoConfiguration
-  cloud:
-      loadbalancer:
-          cache:
-              enabled: false #not needed for build agents
 {% endif %}
 
 

--- a/roles/artemis/templates/artemis.service.j2
+++ b/roles/artemis/templates/artemis.service.j2
@@ -25,7 +25,6 @@ ExecStart=/usr/bin/java \
     --add-opens java.base/sun.nio.ch=ALL-UNNAMED \
     --add-opens java.management/sun.management=ALL-UNNAMED \
     --add-opens jdk.management/com.sun.management.internal=ALL-UNNAMED \
-    --illegal-access=permit \
     -jar artemis.war \
     --spring.profiles.active={{ artemis_spring_profiles }}
 SuccessExitStatus=143


### PR DESCRIPTION
Artemis 7.0.0 requires JDK21 to run. This PR switches the default version from 17 to 21.

I also did some smaller fixes for build agents nodes, as these do not require that much config to be present