### PR TITLE
`Development`: Add Theia configuration

### DIFF
--- a/roles/artemis/defaults/main.yml
+++ b/roles/artemis/defaults/main.yml
@@ -105,8 +105,8 @@ artemis_version_control_default_branch_name: main
 
 enable_science_event_logging: false
 
-theia:
-  portal_url: https://theia-yannik.k8s.ase.cit.tum.de
+#theia:
+#  portal_url: https://theia-yannik.k8s.ase.cit.tum.de
 
 # If the password of some users is stored externally, you need to provide a name and the reset links. They will be displayed as a hint in the reset form of Artemis.
 # You need to at least provide the provider and the English reset link.

--- a/roles/artemis/defaults/main.yml
+++ b/roles/artemis/defaults/main.yml
@@ -105,6 +105,8 @@ artemis_version_control_default_branch_name: main
 
 enable_science_event_logging: false
 
+artemis_theia_base_url: https://theia-yannik.k8s.ase.cit.tum.de
+
 # If the password of some users is stored externally, you need to provide a name and the reset links. They will be displayed as a hint in the reset form of Artemis.
 # You need to at least provide the provider and the English reset link.
 artemis_external_password_provider: TUMonline

--- a/roles/artemis/defaults/main.yml
+++ b/roles/artemis/defaults/main.yml
@@ -105,7 +105,8 @@ artemis_version_control_default_branch_name: main
 
 enable_science_event_logging: false
 
-artemis_theia_base_url: https://theia-yannik.k8s.ase.cit.tum.de
+theia:
+  portal_url: https://theia-yannik.k8s.ase.cit.tum.de
 
 # If the password of some users is stored externally, you need to provide a name and the reset links. They will be displayed as a hint in the reset form of Artemis.
 # You need to at least provide the provider and the English reset link.
@@ -248,10 +249,11 @@ artemis_spring_profile_apollon: "{% if apollon_url is defined and apollon_url is
 artemis_spring_profile_scheduling: "{% if node_id is defined and node_id == 1 %},scheduling{% endif %}"
 artemis_spring_profile_docker: "{% if use_docker %},docker{% endif %}"
 artemis_spring_profile_iris: "{% if iris is defined and iris is not none %},iris{% endif %}"
+artemis_spring_profile_theia: "{% if theia is defined and theia is not none %},theia{% endif %}"
 artemis_spring_profile_aeolus: "{% if aeolus is defined and aeolus is not none %},aeolus{% endif %}"
 artemis_spring_profile_lti: "{% if lti.oauth_secret is defined and lti.oauth_secret is not none %},lti{% endif %}"
 
-artemis_spring_profile_core: "{% if artemis_computed_is_core_node %},core{{ artemis_spring_profile_user_management }}{{ artemis_spring_profile_ldap }}{{ artemis_spring_profile_version_control }}{{ artemis_spring_profile_continuous_integration }}{{ artemis_spring_profile_athena }}{{ artemis_spring_profile_scheduling }}{{ artemis_spring_profile_docker }}{{ artemis_spring_profile_iris }}{{ artemis_spring_profile_aeolus }}{{ artemis_spring_profile_lti }}{% endif %}"
+artemis_spring_profile_core: "{% if artemis_computed_is_core_node %},core{{ artemis_spring_profile_user_management }}{{ artemis_spring_profile_ldap }}{{ artemis_spring_profile_version_control }}{{ artemis_spring_profile_continuous_integration }}{{ artemis_spring_profile_athena }}{{ artemis_spring_profile_scheduling }}{{ artemis_spring_profile_docker }}{{ artemis_spring_profile_iris }}{{ artemis_spring_profile_theia }}{{ artemis_spring_profile_aeolus }}{{ artemis_spring_profile_lti }}{% endif %}"
 artemis_spring_profile_buildagent: "{% if continuous_integration.localci is defined and continuous_integration.localci is not none %}{% if continuous_integration.localci.is_build_agent is defined and continuous_integration.localci.is_build_agent is not none and continuous_integration.localci.is_build_agent %},buildagent{% endif %}{% endif %}"
 
 artemis_spring_profiles: "{{ artemis_spring_profile_env }}{{ artemis_spring_profile_buildagent }}{{ artemis_spring_profile_core }}"

--- a/roles/artemis/templates/application-prod.yml.j2
+++ b/roles/artemis/templates/application-prod.yml.j2
@@ -297,9 +297,11 @@ artemis:
 {% endif %}
 {% endif %}
 
-{% if theia.portal_url is defined and theia.portal_url is not none %}
+{% if theia is defined and theia is not none %}
 theia:
+{% if theia.portal_url is defined and theia.portal_url is not none %}
   portal-url: {{ theia.portal_url }}
+{% endif %}
 {% endif %}
 
 {% if aeolus.url is defined and aeolus.url is not none %}

--- a/roles/artemis/templates/application-prod.yml.j2
+++ b/roles/artemis/templates/application-prod.yml.j2
@@ -291,9 +291,9 @@ artemis:
 {% endif %}
 {% endif %}
 
-{% if artemis_theia_base_url is defined and artemis_theia_base_url is not none %}
-  theia:
-    portal-url: {{ artemis_theia_base_url }}
+{% if theia.portal_url is defined and theia.portal_url is not none %}
+theia:
+  portal-url: {{ theia.portal_url }}
 {% endif %}
 
 {% if aeolus.url is defined and aeolus.url is not none %}
@@ -303,8 +303,6 @@ aeolus:
   token: {{ aeolus.token }}
 {% endif %}
 {% endif %}
-
-
 
 jhipster:
 

--- a/roles/artemis/templates/application-prod.yml.j2
+++ b/roles/artemis/templates/application-prod.yml.j2
@@ -291,6 +291,11 @@ artemis:
 {% endif %}
 {% endif %}
 
+{% if artemis_theia_base_url is defined and artemis_theia_base_url is not none %}
+  theia:
+    portal-url: {{ artemis_theia_base_url }}
+{% endif %}
+
 {% if aeolus.url is defined and aeolus.url is not none %}
 aeolus:
   url: {{ aeolus.url }}
@@ -298,6 +303,8 @@ aeolus:
   token: {{ aeolus.token }}
 {% endif %}
 {% endif %}
+
+
 
 jhipster:
 

--- a/roles/artemis/templates/artemis.env.j2
+++ b/roles/artemis/templates/artemis.env.j2
@@ -192,8 +192,8 @@ ARTEMIS_IRIS_SECRETTOKEN='{{ iris.secret }}'
 {% if enable_science_event_logging is defined %}
 ARTEMIS_SCIENCE_EVENTLOGGING_ENABLE='{{ enable_science_event_logging | lower }}'
 {% endif %}
-{% if artemis_theia_base_url is defined and artemis_theia_base_url is not none %}
-ARTEMIS_THEIA_BASE_URL='{{ artemis_theia_base_url }}'
+{% if theia.portal_url is defined and theia.portal_url is not none %}
+THEIA_PORTALURL='{{ theia.portal_url }}'
 {% endif %}
 {% if aeolus.url is defined and aeolus.url is not none %}
 AEOLUS_URL='{{ aeolus.url }}'

--- a/roles/artemis/templates/artemis.env.j2
+++ b/roles/artemis/templates/artemis.env.j2
@@ -192,6 +192,9 @@ ARTEMIS_IRIS_SECRETTOKEN='{{ iris.secret }}'
 {% if enable_science_event_logging is defined %}
 ARTEMIS_SCIENCE_EVENTLOGGING_ENABLE='{{ enable_science_event_logging | lower }}'
 {% endif %}
+{% if artemis_theia_base_url is defined and artemis_theia_base_url is not none %}
+ARTEMIS_THEIA_BASE_URL='{{ artemis_theia_base_url }}'
+{% endif %}
 {% if aeolus.url is defined and aeolus.url is not none %}
 AEOLUS_URL='{{ aeolus.url }}'
 {% if aeolus.token is defined and aeolus.token is not none %}

--- a/roles/artemis/templates/artemis.env.j2
+++ b/roles/artemis/templates/artemis.env.j2
@@ -198,8 +198,10 @@ ARTEMIS_IRIS_SECRETTOKEN='{{ iris.secret }}'
 {% if enable_science_event_logging is defined %}
 ARTEMIS_SCIENCE_EVENTLOGGING_ENABLE='{{ enable_science_event_logging | lower }}'
 {% endif %}
+{% if theia is defined and theia is not none %}
 {% if theia.portal_url is defined and theia.portal_url is not none %}
 THEIA_PORTALURL='{{ theia.portal_url }}'
+{% endif %}
 {% endif %}
 {% if aeolus.url is defined and aeolus.url is not none %}
 AEOLUS_URL='{{ aeolus.url }}'


### PR DESCRIPTION
This PR implements changes requested by the ITG in [this issue](https://jira.ase.in.tum.de/browse/LS1ADMIN-38042).

Currently, the ongoing integration of Theia into Artemis requires some new configuration values. This PR adds the `theia_base_url` to prod and env templates and the defaults. 

@Hialus are the changes in `artemis.env.j2` sufficient or are there other changes necessary in some, e.g., Dockerfile?