### PR TITLE
Fix file permissions for `artemis_ssh_key_path`

### DIFF
--- a/roles/artemis/defaults/main.yml
+++ b/roles/artemis/defaults/main.yml
@@ -76,7 +76,6 @@ artemis_plagiarism_checks_plagiarism_results_limit: 100
 
 artemis_ssh_key_path: /opt/keys
 artemis_ssh_key_name: "artemis_ssh_key"
-artemis_ssh_priv_key_value: #FIXME
 artemis_ssh_key_password:
 
 artemis_force_restart: false        # Will restart the artemis service on all nodes (unless artemis_force_no_restart) is set

--- a/roles/artemis/tasks/artemis_configuration.yml
+++ b/roles/artemis/tasks/artemis_configuration.yml
@@ -65,26 +65,6 @@
   file:
     path: "{{ artemis_ssh_key_path }}"
     state: directory
-    mode: '0775'
-  when: artemis_ssh_priv_key_value is not none and artemis_ssh_key_path is not none and artemis_ssh_key_path != ""
-
-- name: Copy ssh key
-  become: true
-  copy:
-    content: "{{ artemis_ssh_priv_key_value }}"
-    dest: "{{ artemis_ssh_key_path }}/{{ artemis_ssh_key_name }}"
-  register: ssh_key
-  notify: restart artemis
-  when: artemis_ssh_priv_key_value is not none and artemis_ssh_key_path is not none and artemis_ssh_key_path != ""
-
-- name: Set permissions for artemis ssh key directory
-  become: true
-  file:
-    path: "{{ artemis_ssh_key_path }}"
-    state: directory
-    recurse: yes
-    owner: "{{ artemis_user_name }}"
-    group: "{{ artemis_user_group }}"
   when: artemis_ssh_priv_key_value is not none and artemis_ssh_key_path is not none and artemis_ssh_key_path != ""
 
 - name: Create artemis data-export directory

--- a/roles/artemis/tasks/docker_deploy_artemis.yml
+++ b/roles/artemis/tasks/docker_deploy_artemis.yml
@@ -109,27 +109,6 @@
   file:
     path: "{{ artemis_ssh_key_path }}"
     state: directory
-    mode: '0775'
-  when: artemis_ssh_key_path is not none and artemis_ssh_key_path != ""
-
-- name: Copy ssh key
-  become: true
-  copy:
-    content: "{{ artemis_ssh_priv_key_value }}"
-    dest: "{{ artemis_ssh_key_path }}/{{ artemis_ssh_key_name }}"
-  register: ssh_key
-  notify: restart docker artemis
-  when: artemis_ssh_key_path is not none and artemis_ssh_key_path != ""
-
-- name: Set permissions for artemis ssh key directory
-  become: true
-  file:
-    path: "{{ artemis_ssh_key_path }}"
-    state: directory
-    recurse: yes
-    owner: "{{ artemis_user_name }}"
-    group: "{{ artemis_user_group }}"
-    mode: '0770'
   when: artemis_ssh_key_path is not none and artemis_ssh_key_path != ""
 
 - name: Create artemis data-export directory


### PR DESCRIPTION
We have `artemis_ssh_key_path` set to `/tmp`. Setting the file permissions for `/tmp` results in problems.

Also `artemis_ssh_priv_key_value` is not needed anymore.