### PR TITLE
`Fix`: Ignore exit code of nginx reload

### DIFF
--- a/roles/artemis/templates/artemis-docker.sh.j2
+++ b/roles/artemis/templates/artemis-docker.sh.j2
@@ -36,7 +36,7 @@ function start {
     docker compose --project-directory "$PROJECT_DIR" -f "$PROJECT_DIR/$COMPOSE_FILE" --env-file "$ENV_FILE" up -d --pull always --no-build --remove-orphans
     
     # Reload Nginx configuration as Nginx may still be running from a previous start. This is necessary to apply the new configuration.
-    docker compose --project-directory "$PROJECT_DIR" -f "$PROJECT_DIR/$COMPOSE_FILE" --env-file "$ENV_FILE" exec nginx nginx -s reload
+    docker compose --project-directory "$PROJECT_DIR" -f "$PROJECT_DIR/$COMPOSE_FILE" --env-file "$ENV_FILE" exec nginx nginx -s reload || true
 }
 
 function stop {


### PR DESCRIPTION
We recently added the command to reload the nginx config after the Artemis was started (#114).

In the case of a new Nginx container, the Nginx service might not be running already. Reloading the config will result in a error exit code. This has no negative implications as Artemis is running as expected. Nevertheless, our CI pipeline for deploying Artemis will fail and won't lock the test server, even though technically the deployment was successful.

Thus, we added `|| true` to ignore the exit code in case of an error.