### PR TITLE
Development: Initialise servers and redirects with empty array

### DIFF
--- a/roles/proxy/defaults/main.yml
+++ b/roles/proxy/defaults/main.yml
@@ -1,11 +1,11 @@
 ---
-servers:
+servers: []
 #   - name:
 #     ssl_certificate_path:
 #     ssl_certificate_key_path:
 #     default_server: false
 
-redirects:
+redirects: []
 #   - name:
 #     ssl_certificate_path:
 #     ssl_certificate_key_path:


### PR DESCRIPTION
Not setting servers or redirects will result in an error when executing Ansible.

With the default, we ensure that the playbook executes without an error and (if unset) adds no server block.