### PR TITLE
`Development`: Add variables for the passkey feature

### DIFF
--- a/roles/artemis/defaults/main.yml
+++ b/roles/artemis/defaults/main.yml
@@ -122,10 +122,6 @@ artemis_external_password_provider: TUMonline
 artemis_external_password_reset_link_en: "https://campus.tum.de/tumonline/ee/ui/ca2/app/desktop/#/pl/ui/$ctx/co_loc_password_reset.main?$ctx=design=ca2;header=max;lang=en"
 artemis_external_password_reset_link_de: "https://campus.tum.de/tumonline/ee/ui/ca2/app/desktop/#/pl/ui/$ctx/co_loc_password_reset.main?$ctx=design=ca2;header=max;lang=de"
 
-#passkey:
-#  allowed_origins: "https://artemis.tum.de/"
-#  rp_id: "artemis.tum.de"
-#
 #ldap:
 #  url: "ldaps://iauth.tum.de:636"
 #  user_dn: "cn=TUINI01-Artemis,ou=bindDNs,ou=iauth,dc=tum,dc=de"

--- a/roles/artemis/defaults/main.yml
+++ b/roles/artemis/defaults/main.yml
@@ -122,6 +122,8 @@ artemis_external_password_provider: TUMonline
 artemis_external_password_reset_link_en: "https://campus.tum.de/tumonline/ee/ui/ca2/app/desktop/#/pl/ui/$ctx/co_loc_password_reset.main?$ctx=design=ca2;header=max;lang=en"
 artemis_external_password_reset_link_de: "https://campus.tum.de/tumonline/ee/ui/ca2/app/desktop/#/pl/ui/$ctx/co_loc_password_reset.main?$ctx=design=ca2;header=max;lang=de"
 
+artemis_passkey_enabled: false
+
 #ldap:
 #  url: "ldaps://iauth.tum.de:636"
 #  user_dn: "cn=TUINI01-Artemis,ou=bindDNs,ou=iauth,dc=tum,dc=de"

--- a/roles/artemis/defaults/main.yml
+++ b/roles/artemis/defaults/main.yml
@@ -121,6 +121,11 @@ push_notification_relay: "https://hermes.artemis.cit.tum.de"
 artemis_external_password_provider: TUMonline
 artemis_external_password_reset_link_en: "https://campus.tum.de/tumonline/ee/ui/ca2/app/desktop/#/pl/ui/$ctx/co_loc_password_reset.main?$ctx=design=ca2;header=max;lang=en"
 artemis_external_password_reset_link_de: "https://campus.tum.de/tumonline/ee/ui/ca2/app/desktop/#/pl/ui/$ctx/co_loc_password_reset.main?$ctx=design=ca2;header=max;lang=de"
+
+#passkey:
+#  allowed_origins: "https://artemis.tum.de/"
+#  rp_id: "artemis.tum.de"
+#
 #ldap:
 #  url: "ldaps://iauth.tum.de:636"
 #  user_dn: "cn=TUINI01-Artemis,ou=bindDNs,ou=iauth,dc=tum,dc=de"

--- a/roles/artemis/templates/application-prod.yml.j2
+++ b/roles/artemis/templates/application-prod.yml.j2
@@ -103,6 +103,10 @@ artemis:
 {% else %}
     use-external: false
 {% endif %}
+    passkey:
+      enabled: {{ artemis_passkey_enabled | lower }}
+      allowed-origins: '{{ artemis_passkey_allowed_origins }}'
+      rp-id: '{{ artemis_passkey_rp_id }}'
 
 {% if artemis_external_password_provider is defined and artemis_external_password_provider is not none %}
     password-reset:

--- a/roles/artemis/templates/application-prod.yml.j2
+++ b/roles/artemis/templates/application-prod.yml.j2
@@ -106,8 +106,6 @@ artemis:
 {% if passkey is defined and passkey is not none %}
     passkey:
       enabled: true
-      allowed-origins: '{{ passkey.allowed_origins }}'
-      rp-id: '{{ passkey.rp_id }}'
 {% endif %}
 {% if artemis_external_password_provider is defined and artemis_external_password_provider is not none %}
     password-reset:

--- a/roles/artemis/templates/application-prod.yml.j2
+++ b/roles/artemis/templates/application-prod.yml.j2
@@ -103,11 +103,12 @@ artemis:
 {% else %}
     use-external: false
 {% endif %}
+{% if passkey is defined and passkey is not none %}
     passkey:
-      enabled: {{ artemis_passkey_enabled | lower }}
-      allowed-origins: '{{ artemis_passkey_allowed_origins }}'
-      rp-id: '{{ artemis_passkey_rp_id }}'
-
+      enabled: true
+      allowed-origins: '{{ passkey.allowed_origins }}'
+      rp-id: '{{ passkey.rp_id }}'
+{% endif %}
 {% if artemis_external_password_provider is defined and artemis_external_password_provider is not none %}
     password-reset:
       credential-provider: {{artemis_external_password_provider }}

--- a/roles/artemis/templates/application-prod.yml.j2
+++ b/roles/artemis/templates/application-prod.yml.j2
@@ -103,7 +103,7 @@ artemis:
 {% else %}
     use-external: false
 {% endif %}
-{% if passkey is defined and passkey is not none %}
+{% if artemis_passkey_enabled %}
     passkey:
       enabled: true
 {% endif %}

--- a/roles/artemis/templates/artemis.env.j2
+++ b/roles/artemis/templates/artemis.env.j2
@@ -56,7 +56,7 @@ ARTEMIS_PUSHNOTIFICATIONRELAY='{{ push_notification_relay }}'
 {% endif %}
 ARTEMIS_USERMANAGEMENT_USEEXTERNAL='false'
 {% if passkey is defined and passkey is not none %}
-ARTEMIS_USERMANAGEMENT_PASSKEY_ENABLED='true
+ARTEMIS_USERMANAGEMENT_PASSKEY_ENABLED='true'
 ARTEMIS_USERMANAGEMENT_PASSKEY_ALLOWEDORIGINS='{{ passkey.allowed_origins }}'
 ARTEMIS_USERMANAGEMENT_PASSKEY_RPID='{{ passkey.rp_id }}'
 {% endif %}

--- a/roles/artemis/templates/artemis.env.j2
+++ b/roles/artemis/templates/artemis.env.j2
@@ -57,8 +57,6 @@ ARTEMIS_PUSHNOTIFICATIONRELAY='{{ push_notification_relay }}'
 ARTEMIS_USERMANAGEMENT_USEEXTERNAL='false'
 {% if passkey is defined and passkey is not none %}
 ARTEMIS_USERMANAGEMENT_PASSKEY_ENABLED='true'
-ARTEMIS_USERMANAGEMENT_PASSKEY_ALLOWEDORIGINS='{{ passkey.allowed_origins }}'
-ARTEMIS_USERMANAGEMENT_PASSKEY_RPID='{{ passkey.rp_id }}'
 {% endif %}
 {% if ldap.url is defined and ldap.user_dn is defined and ldap.base is defined and ldap.password is defined %}
 ARTEMIS_USERMANAGEMENT_LDAP_URL='{{ ldap.url }}'

--- a/roles/artemis/templates/artemis.env.j2
+++ b/roles/artemis/templates/artemis.env.j2
@@ -55,6 +55,11 @@ ARTEMIS_BCRYPTSALTROUNDS='{{ artemis_bcrypt_salt_rounds }}'
 ARTEMIS_PUSHNOTIFICATIONRELAY='{{ push_notification_relay }}'
 {% endif %}
 ARTEMIS_USERMANAGEMENT_USEEXTERNAL='false'
+{% if passkey is defined and passkey is not none %}
+ARTEMIS_USERMANAGEMENT_PASSKEY_ENABLED='true
+ARTEMIS_USERMANAGEMENT_PASSKEY_ALLOWEDORIGINS='{{ passkey.allowed_origins }}'
+ARTEMIS_USERMANAGEMENT_PASSKEY_RPID='{{ passkey.rp_id }}'
+{% endif %}
 {% if ldap.url is defined and ldap.user_dn is defined and ldap.base is defined and ldap.password is defined %}
 ARTEMIS_USERMANAGEMENT_LDAP_URL='{{ ldap.url }}'
 ARTEMIS_USERMANAGEMENT_LDAP_USERDN='{{ ldap.user_dn }}'

--- a/roles/artemis/templates/artemis.env.j2
+++ b/roles/artemis/templates/artemis.env.j2
@@ -55,7 +55,7 @@ ARTEMIS_BCRYPTSALTROUNDS='{{ artemis_bcrypt_salt_rounds }}'
 ARTEMIS_PUSHNOTIFICATIONRELAY='{{ push_notification_relay }}'
 {% endif %}
 ARTEMIS_USERMANAGEMENT_USEEXTERNAL='false'
-{% if passkey is defined and passkey is not none %}
+{% if artemis_passkey_enabled %}
 ARTEMIS_USERMANAGEMENT_PASSKEY_ENABLED='true'
 {% endif %}
 {% if ldap.url is defined and ldap.user_dn is defined and ldap.base is defined and ldap.password is defined %}


### PR DESCRIPTION
[General: Add passkey login option #10656](https://github.com/ls1intum/Artemis/pull/10656) adds a login via passkey to Artemis.

Therefore we need to add the following config values to the `application.yml`

```
artemis:
    user-management:
      passkey:
        enabled: true
```

We will also need to define `allowed-origins` and `rp-id` which would be e.g.

```
allowed-origins: "https://artemis-test1.artemis.cit.tum.de"
rp-id: "artemis-test1.artemis.cit.tum.de"
```
And therefore differ for each test server. However, to reduce the configuration overhead, we will assume `server.url` + `server.port` to equal the clientUrl (=allowed-origins). 
For local development and deviations the `client.port` can be defined and will be used as preceding value, if not defined, `server.port` will be used.

Where the `allowed-origins` and `rp-id` differs for each test server. If not set properly, the creation of webauthn credentials and authentication via passkey will be denied.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Introduced a new configuration parameter to enable or disable passkey functionality.
	- Added a new environment variable for dynamic passkey management in the user management system.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->