### PR TITLE
Remove old only_update_artemis_config var

### DIFF
--- a/roles/artemis/tasks/docker_deploy_artemis.yml
+++ b/roles/artemis/tasks/docker_deploy_artemis.yml
@@ -103,7 +103,6 @@
   when:
     - version_control.localvc is defined and version_control.localvc is not none
     - version_control.localvc.ssh_key_path is defined and version_control.localvc.ssh_key_path|length > 0
-    - not (only_update_artemis_config | bool)
 
 - name: Create artemis ssh key directory
   become: true


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated deployment process to always generate SSH keys when certain version control settings are met, regardless of configuration update status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->