### PR TITLE
`Development`: Move add_header to server so that HSTS is enabled again

### DIFF
--- a/roles/proxy/templates/nginx_proxy.conf.j2
+++ b/roles/proxy/templates/nginx_proxy.conf.j2
@@ -53,6 +53,8 @@ server {
     resolver {{ proxy_resolver }};
     resolver_timeout 5s;
     add_header Strict-Transport-Security "max-age=63072000; includeSubDomains; preload";
+    # used to advertise the availability of HTTP/3
+    add_header alt-svc 'h3=":443"; ma=2592000,h3-29=":443"; ma=2592000';
     client_max_body_size 10m;
     client_body_buffer_size 1m;
 
@@ -76,8 +78,6 @@ server {
         fastcgi_send_timeout 900s;
         fastcgi_read_timeout 900s;
         client_max_body_size 128M;
-        # used to advertise the availability of HTTP/3
-        add_header alt-svc 'h3=":443"; ma=2592000,h3-29=":443"; ma=2592000';
     }
 
 {% if proxy_mailto is not none %}
@@ -140,6 +140,8 @@ server {
     resolver {{ proxy_resolver }};
     resolver_timeout 5s;
     add_header Strict-Transport-Security "max-age=63072000; includeSubDomains; preload";
+    # used to advertise the availability of HTTP/3
+    add_header alt-svc 'h3=":443"; ma=2592000,h3-29=":443"; ma=2592000';
     client_max_body_size 10m;
     client_body_buffer_size 1m;
 
@@ -163,8 +165,6 @@ server {
         fastcgi_send_timeout 900s;
         fastcgi_read_timeout 900s;
         client_max_body_size 128M;
-        # used to advertise the availability of HTTP/3
-        add_header alt-svc 'h3=":443"; ma=2592000,h3-29=":443"; ma=2592000';
     }
 
     location /api/authenticate {


### PR DESCRIPTION
Previously, we had `add_header` in the `server` for HSTS and `add_header` in the `location /` for advertising HTTP/3.
The problem is that the `add_header` in the location is overwritten by the `add_header` for H3.

We moved all `add_header`s to the server directive so that no header definition is overwritten.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Consolidated the HTTP/3 advertisement header to the server level for improved consistency and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->