### PR TITLE
`Development`: Speedup deployment using synchronize to copy artemis.war

### DIFF
--- a/roles/artemis/tasks/deploy_artemis.yml
+++ b/roles/artemis/tasks/deploy_artemis.yml
@@ -15,9 +15,19 @@
 
 - name: Copy local Artemis.war to {{ artemis_working_directory }}
   become: true
-  copy:
+  synchronize:
     src: "{{ artemis_version }}"
     dest: "{{ artemis_working_directory }}/artemis.war.new"
+    mode: push
+    archive: true
+    owner: false
+    group: false
+  when: not (is_release | bool)
+
+- name: Set correct ownership and permissions on artemis.war.new
+  become: true
+  file:
+    path: "{{ artemis_working_directory }}/artemis.war.new"
     owner: "{{ artemis_user_name }}"
     group: "{{ artemis_user_group }}"
     mode: "644"

--- a/roles/artemis/tasks/deploy_artemis.yml
+++ b/roles/artemis/tasks/deploy_artemis.yml
@@ -15,7 +15,7 @@
 
 - name: Copy local Artemis.war to {{ artemis_working_directory }}
   become: true
-  synchronize:
+  ansible.posix.synchronize:
     src: "{{ artemis_version }}"
     dest: "{{ artemis_working_directory }}/artemis.war.new"
     mode: push


### PR DESCRIPTION
I tested the deployment to Staging 1. Nevertheless, I haven't checked that there is a speedup. My wifi connection is too bad for proper benchmarks. We have to see how this will behave when used for the deployments via GitHub.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Improved the process for copying and setting permissions on the Artemis.war file during deployment for non-release versions. This ensures correct file ownership and permissions after deployment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->