### PR TITLE
`Development`: Adapt handling of artemis.war.new and artemis.war.old

### DIFF
--- a/roles/artemis/tasks/deploy_artemis.yml
+++ b/roles/artemis/tasks/deploy_artemis.yml
@@ -28,7 +28,7 @@
   become: true
   file:
     path: "{{ artemis_working_directory }}/artemis.war.new"
-    owner: "{{ artemis_user_name }}"
+    owner: "{{ artemis_deployment_user_name }}"
     group: "{{ artemis_user_group }}"
     mode: "644"
   when: not (is_release | bool)
@@ -38,7 +38,7 @@
   get_url:
     url: "{{ artemis_war_url }}"
     dest: "{{ artemis_working_directory }}/artemis.war.new"
-    owner: "{{ artemis_user_name }}"
+    owner: "{{ artemis_deployment_user_name }}"
     group: "{{ artemis_user_group }}"
     mode: "644"
     force: true

--- a/roles/artemis/tasks/restart_artemis.yml
+++ b/roles/artemis/tasks/restart_artemis.yml
@@ -15,6 +15,19 @@
     - node_id is defined
     - node_id == 1
 
+- name: Copy Artemis.war to Artemis.war.old
+  become: true
+  copy:
+    src: "{{ artemis_working_directory }}/artemis.war"
+    remote_src: true
+    dest: "{{ artemis_working_directory }}/artemis.war.old"
+    owner: "{{ artemis_deployment_user_name }}"
+    group: "{{ artemis_user_group }}"
+    mode: "644"
+  when:
+    - download_artemis_application | bool
+    - not ansible_check_mode
+
 - name: Copy Artemis.war.new to Artemis.war
   become: true
   copy:

--- a/roles/artemis/tasks/restart_artemis.yml
+++ b/roles/artemis/tasks/restart_artemis.yml
@@ -15,6 +15,12 @@
     - node_id is defined
     - node_id == 1
 
+- name: Check that the Artemis.war exists
+  become: true
+  stat:
+    path: "{{ artemis_working_directory }}/artemis.war"
+  register: artemis_war_stat
+
 - name: Copy Artemis.war to Artemis.war.old
   become: true
   copy:
@@ -27,6 +33,7 @@
   when:
     - download_artemis_application | bool
     - not ansible_check_mode
+    - artemis_war_stat.stat.exists
 
 - name: Copy Artemis.war.new to Artemis.war
   become: true


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated deployment tasks to use a different user for file ownership during application updates.
  - Added a backup step to preserve the existing application file before replacement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->