### PR TITLE
`Development`: Add passwort reset information in artemis.env for docker-based systems

### DIFF
--- a/roles/artemis/templates/artemis.env.j2
+++ b/roles/artemis/templates/artemis.env.j2
@@ -56,6 +56,11 @@ ARTEMIS_USERMANAGEMENT_USEEXTERNAL='false'
 {% if artemis_passkey_enabled %}
 ARTEMIS_USERMANAGEMENT_PASSKEY_ENABLED='true'
 {% endif %}
+{% if artemis_external_password_provider is defined and artemis_external_password_provider is not none %}
+ARTEMIS_USERMANAGEMENT_PASSWORDRESET_CREDENTIALPROVIDER='{{ artemis_external_password_provider }}'
+ARTEMIS_USERMANAGEMENT_PASSWORDRESET_LINKS_EN='{{ artemis_external_password_reset_link_en }}'
+ARTEMIS_USERMANAGEMENT_PASSWORDRESET_LINKS_DE='{{ artemis_external_password_reset_link_de }}'
+{% endif %}
 {% if ldap.url is defined and ldap.user_dn is defined and ldap.base is defined and ldap.password is defined %}
 ARTEMIS_USERMANAGEMENT_LDAP_URL='{{ ldap.url }}'
 ARTEMIS_USERMANAGEMENT_LDAP_USERDN='{{ ldap.user_dn }}'


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for configuring external password reset providers, including environment variables for provider selection and password reset links in English and German.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->