### PR TITLE
`Development`: Remove ldap-only

### DIFF
--- a/roles/artemis/defaults/main.yml
+++ b/roles/artemis/defaults/main.yml
@@ -250,7 +250,7 @@ artemis_computed_is_core_node: "{{ not (continuous_integration.localci is define
 
 # Compute Spring Profiles from set variables
 artemis_spring_profile_env: "prod"
-artemis_spring_profile_ldap: "{% if ldap.password is defined and ldap.password is not none %},ldap-only,ldap{% endif %}"
+artemis_spring_profile_ldap: "{% if ldap.password is defined and ldap.password is not none %},ldap{% endif %}"
 artemis_spring_profile_version_control: "{% if version_control.localvc is defined and version_control.localvc is not none %},localvc{% endif
   %}"
 artemis_spring_profile_continuous_integration: "{% if continuous_integration.jenkins


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Simplified the configuration for LDAP Spring profiles by removing the `ldap-only` profile, ensuring only the `ldap` profile is activated when applicable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->