### PR TITLE
Add option to set entropy bits

### DIFF
--- a/roles/artemis/tasks/artemis_setup.yml
+++ b/roles/artemis/tasks/artemis_setup.yml
@@ -91,6 +91,18 @@
     - version_control.localvc is defined and version_control.localvc is not none
     - version_control.localvc.ssh_key_path is defined and version_control.localvc.ssh_key_path|length > 0
 
+- name: Set entropy bits override for mmap randomization
+  ansible.posix.sysctl:
+    name: vm.mmap_rnd_bits
+    value: "{{ entropy_bits_override }}"
+    state: present
+    reload: yes
+  become: true
+  when:
+    - continuous_integration.localci.is_build_agent is defined
+    - continuous_integration.localci.is_build_agent
+    - entropy_bits_override is defined and entropy_bits_override is defined and entropy_bits_override | int > 0
+
 - name: Copy artemis.service systemd configuration
   become: true
   template:

--- a/roles/artemis/tasks/artemis_setup.yml
+++ b/roles/artemis/tasks/artemis_setup.yml
@@ -96,7 +96,7 @@
     name: vm.mmap_rnd_bits
     value: "{{ entropy_bits_override }}"
     state: present
-    reload: yes
+    reload: true
   become: true
   when:
     - continuous_integration.localci.is_build_agent is defined


### PR DESCRIPTION
Closes #147
Implementation in ls1intum/artemis-ansible#24

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic configuration of the kernel parameter `vm.mmap_rnd_bits` on build agents when applicable, improving system setup during deployment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->