### PR TITLE
`Development`: Add rate limit for passkey login endpoint

### DIFF
--- a/roles/proxy/templates/nginx_proxy.conf.j2
+++ b/roles/proxy/templates/nginx_proxy.conf.j2
@@ -98,6 +98,17 @@ server {
         limit_req zone=loginlimit burst=3 delay=2;
     }
 
+    location /login/webauthn {
+        proxy_pass http://app/login/webauthn;
+		# For a given violation of the rate limit defined in the zone
+		# * the first 2 (delay) requests will be allowed without delay
+		# * the next (burst - delay) request waits until it fits in the rate limit
+		# * the rest will be denied
+		# If an attacker spams this endpoint, only the first three requests will come through.
+		# This only resets if the violation of the rate limit stops.
+        limit_req zone=loginlimit burst=3 delay=2;
+    }
+
     location /favicon.ico {
         return 404;
     }
@@ -165,17 +176,6 @@ server {
         fastcgi_send_timeout 900s;
         fastcgi_read_timeout 900s;
         client_max_body_size 128M;
-    }
-
-    location /api/authenticate {
-        proxy_pass http://app/api/authenticate;
-		# For a given violation of the rate limit defined in the zone
-		# * the first 2 (delay) requests will be allowed without delay
-		# * the next (burst - delay) request waits until it fits in the rate limit
-		# * the rest will be denied
-		# If an attacker spams this endpoint, only the first three requests will come through.
-		# This only resets if the violation of the rate limit stops.
-        limit_req zone=loginlimit burst=3 delay=2;
     }
 
     location / {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated rate limiting to apply to the `/login/webauthn` endpoint instead of `/api/authenticate`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->