### PR TITLE
`Development`: Fix comment for git operations rate-limit

### DIFF
--- a/roles/proxy/templates/nginx_proxy.conf.j2
+++ b/roles/proxy/templates/nginx_proxy.conf.j2
@@ -113,12 +113,10 @@ server {
 
     location /git/ {
         proxy_pass http://app/git/;
-		# For a given violation of the rate limit defined in the zone
-		# * the first 2 (delay) requests will be allowed without delay
-		# * the next (burst - delay) request waits until it fits in the rate limit
-		# * the rest will be denied
-		# If an attacker spams this endpoint, only the first three requests will come through.
-		# This only resets if the violation of the rate limit stops.
+        # For a given violation of the rate limit defined in the zone
+        # * the first 30 requests will be allowed without delay
+        # * the rest will be denied
+        # This only resets if the violation of the rate limit stops.
         limit_req zone=gitlimit burst=30 nodelay;
 
         proxy_http_version 1.1;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified configuration comments describing the Git request rate-limiting policy: the first 30 requests are allowed without delay; subsequent requests are denied.
  * This is a documentation-only update with no functional or performance impact; no changes to limits or behavior in production.
  * Users should experience no changes in access or throttling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->