### PR TITLE
Add hyperion config

### DIFF
--- a/roles/artemis/README.md
+++ b/roles/artemis/README.md
@@ -96,6 +96,31 @@ athena:
   restricted_modules: "module_text_llm,module_programming_llm" # optional parameter to restrict access to specific modules
 ```
 
+Hyperion (Azure OpenAI / Spring AI) configuration (adds profile `hyperion` when present):
+
+Define two parts:
+1. Activate profile by declaring an empty or minimal `hyperion:` key.
+2. Configure Spring AI globally under `spring_ai:`.
+
+```yaml
+hyperion: {}
+
+spring_ai:
+  azure_openai:
+    api_key: "{{ vault_azure_openai_api_key }}"
+    endpoint: "https://my-azure-openai-resource.openai.azure.com/"
+    deployment_name: "gpt-5-mini"
+    temperature: 1.0
+```
+Rendered into application-prod.yml under (if spring_ai.azure_openai is present):
+
+```text
+spring.ai.azure.openai.api-key
+spring.ai.azure.openai.endpoint
+spring.ai.azure.openai.chat.options.deployment-name
+spring.ai.azure.openai.chat.options.temperature
+```
+
 Iris configuration:
 ```
 iris:

--- a/roles/artemis/defaults/main.yml
+++ b/roles/artemis/defaults/main.yml
@@ -237,6 +237,22 @@ node_display_name: Unnamed Artemis Node
 # More configuration options will be added in the future.
 
 ##############################################################################
+# Hyperion / Spring AI (Azure OpenAI) Configuration
+##############################################################################
+# Define Spring AI configuration once.
+# To enable Hyperion features, define an (even empty) 'hyperion:' block to trigger the profile
+# and configure Azure OpenAI under spring_ai.azure_openai. Example:
+#
+#spring_ai:
+#  azure_openai:
+#    api_key: ""
+#    endpoint: "https://your-resource-name.openai.azure.com/"
+#    deployment_name: "gpt-5-mini"
+#    temperature: 1.0
+#
+#hyperion: {}
+
+##############################################################################
 # CORS Configuration
 ##############################################################################
 #artemis_CORS_allowed_origins: "*"
@@ -285,11 +301,12 @@ artemis_spring_profile_aeolus: "{% if aeolus is defined and aeolus is not none %
 artemis_spring_profile_atlas: "{% if atlas is defined %},atlas{% endif %}" # TODO: Add and atlas is not none check as soon as the additional configuration options are added
 artemis_spring_profile_lti: "{% if lti.oauth_secret is defined and lti.oauth_secret is not none %},lti{% endif %}"
 artemis_spring_profile_sharing: "{% if sharing is defined and sharing is not none %},sharing{% endif %}"
+artemis_spring_profile_hyperion: "{% if hyperion is defined %},hyperion{% endif %}"
 
 artemis_spring_profile_core: "{% if artemis_computed_is_core_node %},core{{ artemis_spring_profile_ldap }}{{ artemis_spring_profile_version_control
   }}{{ artemis_spring_profile_continuous_integration }}{{ artemis_spring_profile_athena }}{{ artemis_spring_profile_apollon }}{{ artemis_spring_profile_scheduling }}{{ artemis_spring_profile_docker
   }}{{ artemis_spring_profile_iris }}{{ artemis_spring_profile_theia }}{{ artemis_spring_profile_aeolus }}{{ artemis_spring_profile_atlas }}{{ artemis_spring_profile_lti
-  }}{{ artemis_spring_profile_sharing }}{% endif %}"
+  }}{{ artemis_spring_profile_sharing }}{{ artemis_spring_profile_hyperion }}{% endif %}"
 artemis_spring_profile_buildagent: "{% if continuous_integration.localci is defined and continuous_integration.localci is not none %}{% if continuous_integration.localci.is_build_agent
   is defined and continuous_integration.localci.is_build_agent is not none and continuous_integration.localci.is_build_agent %},buildagent{% endif %}{% endif %}"
 

--- a/roles/artemis/tasks/variable_checks.yml
+++ b/roles/artemis/tasks/variable_checks.yml
@@ -28,6 +28,16 @@
     - artemis_jhipster_registry_password is undefined or artemis_jhipster_registry_password is none
     - is_multinode_install|bool
 
+- name: Check Spring AI Azure OpenAI configuration completeness (optional)
+  fail:
+    msg: "spring_ai.azure_openai defined but missing one of: api_key, endpoint, deployment_name"
+  when:
+    - spring_ai is defined
+    - spring_ai.azure_openai is defined
+    - (spring_ai.azure_openai.api_key is not defined or spring_ai.azure_openai.api_key | length == 0)
+      or (spring_ai.azure_openai.endpoint is not defined or spring_ai.azure_openai.endpoint | length == 0)
+      or (spring_ai.azure_openai.deployment_name is not defined or spring_ai.azure_openai.deployment_name | length == 0)
+
 ##############################################################################
 # Check localci Variables
 ##############################################################################

--- a/roles/artemis/templates/application-prod.yml.j2
+++ b/roles/artemis/templates/application-prod.yml.j2
@@ -35,6 +35,19 @@ spring:
     interface: "{{ hazelcast_address }}"
 {% endif %}
 
+{# Spring AI configuration (only spring_ai.* supported) #}
+{% if spring_ai is defined and spring_ai.azure_openai is defined %}
+  ai:
+    azure:
+      openai:
+        api-key: {{ spring_ai.azure_openai.api_key | quote }}
+        endpoint: {{ spring_ai.azure_openai.endpoint | quote }}
+        chat:
+          options:
+            deployment-name: {{ spring_ai.azure_openai.deployment_name | quote }}
+            temperature: {{ spring_ai.azure_openai.temperature | default(1.0) }}
+{% endif %}
+
 {% if artemis_computed_is_core_node %}
 {% if shared_monitoring_host_v4 is not none %}
   prometheus:

--- a/roles/artemis/templates/application-prod.yml.j2
+++ b/roles/artemis/templates/application-prod.yml.j2
@@ -35,7 +35,6 @@ spring:
     interface: "{{ hazelcast_address }}"
 {% endif %}
 
-{# Spring AI configuration (only spring_ai.* supported) #}
 {% if spring_ai is defined and spring_ai.azure_openai is defined %}
   ai:
     azure:

--- a/roles/artemis/templates/artemis.env.j2
+++ b/roles/artemis/templates/artemis.env.j2
@@ -167,6 +167,13 @@ ARTEMIS_ATHENA_SECRET='{{ athena.secret }}'
 {% if apollon_url is defined %}
 ARTEMIS_APOLLON_CONVERSIONSERVICEURL='{{ apollon_url }}'
 {% endif %}
+{# Generic Spring AI env export (prefers spring_ai.azure_openai, falls back to hyperion.azure_openai) #}
+{% if spring_ai is defined and spring_ai.azure_openai is defined %}
+SPRING_AI_AZURE_OPENAI_API_KEY='{{ spring_ai.azure_openai.api_key }}'
+SPRING_AI_AZURE_OPENAI_ENDPOINT='{{ spring_ai.azure_openai.endpoint }}'
+SPRING_AI_AZURE_OPENAI_CHAT_OPTIONS_DEPLOYMENT_NAME='{{ spring_ai.azure_openai.deployment_name }}'
+SPRING_AI_AZURE_OPENAI_CHAT_OPTIONS_TEMPERATURE='{{ spring_ai.azure_openai.temperature | default(1.0) }}'
+{% endif %}
 {% if iris is defined and iris is not none %}
 ARTEMIS_IRIS_URL='{{ iris.url }}'
 ARTEMIS_IRIS_SECRETTOKEN='{{ iris.secret }}'

--- a/roles/artemis/templates/artemis.env.j2
+++ b/roles/artemis/templates/artemis.env.j2
@@ -167,7 +167,6 @@ ARTEMIS_ATHENA_SECRET='{{ athena.secret }}'
 {% if apollon_url is defined %}
 ARTEMIS_APOLLON_CONVERSIONSERVICEURL='{{ apollon_url }}'
 {% endif %}
-{# Generic Spring AI env export (prefers spring_ai.azure_openai, falls back to hyperion.azure_openai) #}
 {% if spring_ai is defined and spring_ai.azure_openai is defined %}
 SPRING_AI_AZURE_OPENAI_API_KEY='{{ spring_ai.azure_openai.api_key }}'
 SPRING_AI_AZURE_OPENAI_ENDPOINT='{{ spring_ai.azure_openai.endpoint }}'


### PR DESCRIPTION
This pull request adds support for configuring Hyperion (Azure OpenAI via Spring AI) in Artemis. It introduces new configuration options, documentation, and validation to enable and manage the Hyperion profile, as well as to inject the necessary Azure OpenAI settings into both the application YAML and environment variables. The changes ensure that Hyperion can be enabled simply by adding a minimal `hyperion:` block and configuring Azure OpenAI under `spring_ai`.

**Hyperion (Azure OpenAI / Spring AI) integration:**

* Added documentation in `README.md` describing how to enable the Hyperion profile and configure Azure OpenAI via the `spring_ai` block, including example YAML and a mapping to application properties.
* Added default configuration comments and examples for Hyperion and Spring AI in `main.yml`, clarifying how to activate the profile and where to set Azure OpenAI credentials.

**Spring profile and environment configuration:**

* Updated the computed Spring profile logic to include the Hyperion profile when `hyperion` is defined, ensuring it is activated as part of the core node profile.
* Injected Spring AI Azure OpenAI configuration into the generated `application-prod.yml` if present, mapping `spring_ai.azure_openai` fields to the correct YAML structure.
* Exported Spring AI Azure OpenAI credentials as environment variables in `artemis.env.j2` when configured, making them available to the application at runtime.

**Validation and safety checks:**

* Added a task to fail deployment if `spring_ai.azure_openai` is defined but required fields (`api_key`, `endpoint`, `deployment_name`) are missing, preventing misconfiguration.