### PR TITLE
`Development`: Add role for storage backup

### DIFF
--- a/roles/storage_backup/README.md
+++ b/roles/storage_backup/README.md
@@ -1,0 +1,45 @@
+# Storage Backup
+
+This role adds a cron job to the Storage host which creates regular Storage backups.
+
+## Configuration
+
+The default configuration will create a Storage backup every day at 4:30:
+
+```yml
+storage_export: /srv/artemis
+storage_backup_dir: /opt/backup
+
+storage_backup_script_path: /opt/backup.sh
+storage_backup_compression: zstd
+storage_backup_retention: 30
+storage_backup_minute: 30
+storage_backup_hour: 4
+```
+
+### Variables that have to be configured:
+
+```
+storage_backup_password: "your_storage_backup_password"
+```
+Note that the password can be set to the empty string to store the backup without a password.
+
+## Example Usage
+
+Here is an example playbook:
+
+```yaml
+- hosts: storage
+  roles:
+    - role: ls1intum.storage_backup
+      vars:
+        storage_export: /srv/artemis
+        storage_backup_password: "your_storage_backup_password"
+        storage_backup_dir: /opt/backup
+
+        storage_backup_script_path: /opt/backup.sh
+        storage_backup_compression: zstd
+        storage_backup_retention: 30
+        storage_backup_minute: 30
+        storage_backup_hour: 4
+```

--- a/roles/storage_backup/README.md
+++ b/roles/storage_backup/README.md
@@ -1,12 +1,12 @@
 # Storage Backup
 
-This role adds a cron job to the Storage host which creates regular Storage backups.
+This role adds a cron job to the Storage host which creates regular Storage backups. The encryption keys will be saved to `./decryption_Keys.txt` on the localhost.
 
 ## Configuration
 
 The default configuration will create a Storage backup every day at 4:30:
 
-```yml
+```yaml
 storage_export: /srv/artemis
 storage_backup_dir: /opt/backup
 
@@ -19,7 +19,7 @@ storage_backup_hour: 4
 
 ### Variables that have to be configured:
 
-```
+```yaml
 storage_backup_password: "your_storage_backup_password"
 ```
 Note that the password can be set to the empty string to store the backup without a password.

--- a/roles/storage_backup/README.md
+++ b/roles/storage_backup/README.md
@@ -31,7 +31,7 @@ Here is an example playbook:
 ```yaml
 - hosts: storage
   roles:
-    - role: ls1intum.storage_backup
+    - role: ls1intum.artemis.storage_backup
       vars:
         storage_export: /srv/artemis
         storage_backup_password: "your_storage_backup_password"

--- a/roles/storage_backup/README.md
+++ b/roles/storage_backup/README.md
@@ -2,13 +2,21 @@
 
 This role adds a cron job to the Storage host which creates regular Storage backups. The encryption keys will be saved to `./decryption_Keys.txt` on the localhost.
 
+## Requirements
+You need a borg server at `storage_backup_borg_server_url` with an ssh key set up. The borg server should be added to the known_hosts of the Artemis Storage host.
+
 ## Configuration
 
 The default configuration will create a Storage backup every day at 4:30:
 
 ```yaml
 storage_export: /srv/artemis
-storage_backup_dir: /opt/backup
+
+storage_backup_borg_server_user: borg
+storage_backup_borg_server_user_home: /backup
+storage_backup_borg_ssh_identity: /root/.ssh/id_borg
+storage_backup_borg_server_port: 22
+storage_backup_borg_repo_name: artemis-storage
 
 storage_backup_script_path: /opt/backup.sh
 storage_backup_compression: zstd
@@ -20,6 +28,7 @@ storage_backup_hour: 4
 ### Variables that have to be configured:
 
 ```yaml
+storage_backup_borg_server_url: "your_borg_server_url"
 storage_backup_password: "your_storage_backup_password"
 ```
 Note that the password can be set to the empty string to store the backup without a password.
@@ -33,13 +42,5 @@ Here is an example playbook:
   roles:
     - role: ls1intum.artemis.storage_backup
       vars:
-        storage_export: /srv/artemis
         storage_backup_password: "your_storage_backup_password"
-        storage_backup_dir: /opt/backup
-
-        storage_backup_script_path: /opt/backup.sh
-        storage_backup_compression: zstd
-        storage_backup_retention: 30
-        storage_backup_minute: 30
-        storage_backup_hour: 4
 ```

--- a/roles/storage_backup/defaults/main.yml
+++ b/roles/storage_backup/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 storage_export: /srv/artemis
-storage_backup_password: #FIXME
+storage_backup_password: "" #FIXME
 storage_backup_dir: /opt/backup
 
 storage_backup_script_path: /opt/backup.sh

--- a/roles/storage_backup/defaults/main.yml
+++ b/roles/storage_backup/defaults/main.yml
@@ -1,0 +1,10 @@
+---
+storage_export: /srv/artemis
+storage_backup_password: #FIXME
+storage_backup_dir: /opt/backup
+
+storage_backup_script_path: /opt/backup.sh
+storage_backup_compression: zstd
+storage_backup_retention: 30
+storage_backup_minute: 30
+storage_backup_hour: 4

--- a/roles/storage_backup/defaults/main.yml
+++ b/roles/storage_backup/defaults/main.yml
@@ -1,7 +1,14 @@
 ---
 storage_export: /srv/artemis
 storage_backup_password: "" #FIXME
-storage_backup_dir: /opt/backup
+
+storage_backup_borg_server_user: borg
+storage_backup_borg_server_user_home: /backup
+storage_backup_borg_ssh_identity: /root/.ssh/id_borg
+storage_backup_borg_server_url: "" #FIXME
+storage_backup_borg_server_port: 22
+storage_backup_borg_repo_name: artemis-storage
+
 
 storage_backup_script_path: /opt/backup.sh
 storage_backup_compression: zstd

--- a/roles/storage_backup/tasks/main.yaml
+++ b/roles/storage_backup/tasks/main.yaml
@@ -1,0 +1,49 @@
+---
+- name: Install dependencies
+  become: true
+  ansible.builtin.apt:
+    name:
+      - borgbackup
+    state: present
+    update_cache: true
+
+- name: Initialise Borg repository
+  become: true
+  ansible.builtin.command: borg init --encryption=repokey {{ storage_backup_dir }}
+  environment:
+    BORG_PASSPHRASE: '{{ storage_backup_password }}'
+  register: init_borg_output
+  changed_when: init_borg_output.rc != 2
+  failed_when:
+    - init_borg_output.rc != 2
+    - init_borg_output.rc != 0
+
+- name: Get encryption keys
+  become: true
+  ansible.builtin.command: borg key export --paper {{ storage_backup_dir }}
+  register: borg_keys
+  changed_when: borg_keys.rc != 0
+
+- name: Print encryption keys
+  ansible.builtin.debug:
+    msg: "{{ borg_keys }}"
+
+- name: Save the keys!
+  ansible.builtin.pause:
+    prompt: "Save the keys! (Enter to continue)"
+    echo: yes
+
+- name: Deploy storage backup script
+  become: true
+  template:
+    src: "templates/backup.sh.j2"
+    dest: "{{ storage_backup_script_path }}"
+    mode: "700"
+
+- name: Add backup cronjob
+  become: true
+  ansible.builtin.cron:
+    name: "Backup artemis storage"
+    minute: "{{ storage_backup_minute }}"
+    hour: "{{ storage_backup_hour }}"
+    job: "{{ storage_backup_script_path }} -sp"

--- a/roles/storage_backup/tasks/main.yaml
+++ b/roles/storage_backup/tasks/main.yaml
@@ -30,7 +30,7 @@
 - name: Write keys to file
   copy:
     dest: ./decryption_Keys.txt
-    content: "{{ borg_keys }}"
+    content: "{{ borg_keys.stdout }}"
   delegate_to: localhost
 
 - name: Deploy storage backup script

--- a/roles/storage_backup/tasks/main.yaml
+++ b/roles/storage_backup/tasks/main.yaml
@@ -31,12 +31,13 @@
   copy:
     dest: ./decryption_Keys.txt
     content: "{{ borg_keys.stdout }}"
+    mode: "600"
   delegate_to: localhost
 
 - name: Deploy storage backup script
   become: true
   template:
-    src: "templates/backup.sh.j2"
+    src: "backup.sh.j2"
     dest: "{{ storage_backup_script_path }}"
     mode: "700"
 

--- a/roles/storage_backup/tasks/main.yaml
+++ b/roles/storage_backup/tasks/main.yaml
@@ -31,7 +31,7 @@
 - name: Save the keys!
   ansible.builtin.pause:
     prompt: "Save the keys! (Enter to continue)"
-    echo: yes
+    echo: true
 
 - name: Deploy storage backup script
   become: true

--- a/roles/storage_backup/tasks/main.yaml
+++ b/roles/storage_backup/tasks/main.yaml
@@ -1,7 +1,7 @@
 ---
 - name: Install dependencies
   become: true
-  ansible.builtin.apt:
+  apt:
     name:
       - borgbackup
     state: present
@@ -9,7 +9,7 @@
 
 - name: Initialise Borg repository
   become: true
-  ansible.builtin.command: borg init --encryption=repokey {{ storage_backup_dir }}
+  command: borg init --encryption=repokey {{ storage_backup_dir }}
   environment:
     BORG_PASSPHRASE: '{{ storage_backup_password }}'
   register: init_borg_output
@@ -20,18 +20,18 @@
 
 - name: Get encryption keys
   become: true
-  ansible.builtin.command: borg key export --paper {{ storage_backup_dir }}
+  command: borg key export --paper {{ storage_backup_dir }}
   register: borg_keys
-  changed_when: borg_keys.rc != 0
 
 - name: Print encryption keys
-  ansible.builtin.debug:
+  debug:
     msg: "{{ borg_keys }}"
 
-- name: Save the keys!
-  ansible.builtin.pause:
-    prompt: "Save the keys! (Enter to continue)"
-    echo: true
+- name: Write keys to file
+  copy:
+    dest: ./decryption_Keys.txt
+    content: "{{ borg_keys }}"
+  delegate_to: localhost
 
 - name: Deploy storage backup script
   become: true
@@ -42,7 +42,7 @@
 
 - name: Add backup cronjob
   become: true
-  ansible.builtin.cron:
+  cron:
     name: "Backup artemis storage"
     minute: "{{ storage_backup_minute }}"
     hour: "{{ storage_backup_hour }}"

--- a/roles/storage_backup/tasks/main.yaml
+++ b/roles/storage_backup/tasks/main.yaml
@@ -1,7 +1,7 @@
 ---
 - name: Install dependencies
   become: true
-  apt:
+  ansible.builtin.apt:
     name:
       - borgbackup
     state: present
@@ -9,7 +9,7 @@
 
 - name: Initialise Borg repository
   become: true
-  command: borg init --encryption=repokey {{ storage_backup_dir }}
+  ansible.builtin.command: borg init --encryption=repokey {{ storage_backup_dir }}
   environment:
     BORG_PASSPHRASE: '{{ storage_backup_password }}'
   register: init_borg_output
@@ -20,15 +20,15 @@
 
 - name: Get encryption keys
   become: true
-  command: borg key export --paper {{ storage_backup_dir }}
+  ansible.builtin.command: borg key export --paper {{ storage_backup_dir }}
   register: borg_keys
 
 - name: Print encryption keys
-  debug:
+  ansible.builtin.debug:
     msg: "{{ borg_keys }}"
 
 - name: Write keys to file
-  copy:
+  ansible.builtin.copy:
     dest: ./decryption_Keys.txt
     content: "{{ borg_keys.stdout }}"
     mode: "600"
@@ -36,14 +36,14 @@
 
 - name: Deploy storage backup script
   become: true
-  template:
+  ansible.builtin.template:
     src: "backup.sh.j2"
     dest: "{{ storage_backup_script_path }}"
     mode: "700"
 
 - name: Add backup cronjob
   become: true
-  cron:
+  ansible.builtin.cron:
     name: "Backup artemis storage"
     minute: "{{ storage_backup_minute }}"
     hour: "{{ storage_backup_hour }}"

--- a/roles/storage_backup/tasks/main.yaml
+++ b/roles/storage_backup/tasks/main.yaml
@@ -29,7 +29,7 @@
   ansible.builtin.copy:
     dest: ./decryption_Keys.txt
     content: "{{ borg_keys.stdout }}"
-    mode: "600"
+    mode: "0600"
   delegate_to: localhost
 
 - name: Deploy storage backup script

--- a/roles/storage_backup/tasks/main.yaml
+++ b/roles/storage_backup/tasks/main.yaml
@@ -45,4 +45,4 @@
     name: "Backup artemis storage"
     minute: "{{ storage_backup_minute }}"
     hour: "{{ storage_backup_hour }}"
-    job: "{{ storage_backup_script_path }} -sp"
+    job: "{{ storage_backup_script_path }} -sp >> /var/log/storage-backup.log 2>&1 || echo 'Backup failed' | logger -t storage-backup"

--- a/roles/storage_backup/tasks/main.yaml
+++ b/roles/storage_backup/tasks/main.yaml
@@ -14,9 +14,7 @@
     BORG_PASSPHRASE: '{{ storage_backup_password }}'
   register: init_borg_output
   changed_when: init_borg_output.rc != 2
-  failed_when:
-    - init_borg_output.rc != 2
-    - init_borg_output.rc != 0
+  failed_when: init_borg_output.rc not in [0, 2]
 
 - name: Get encryption keys
   become: true

--- a/roles/storage_backup/tasks/main.yaml
+++ b/roles/storage_backup/tasks/main.yaml
@@ -9,16 +9,19 @@
 
 - name: Initialise Borg repository
   become: true
-  ansible.builtin.command: borg init --encryption=repokey {{ storage_backup_dir }}
+  ansible.builtin.command: borg init --encryption=repokey ssh://{{ storage_backup_borg_server_user }}@{{ storage_backup_borg_server_url }}:{{ storage_backup_borg_server_port }}/{{ storage_backup_borg_server_user_home }}/{{ storage_backup_borg_repo_name }}
   environment:
     BORG_PASSPHRASE: '{{ storage_backup_password }}'
+    BORG_RSH: "'ssh -i ' ~ storage_backup_borg_ssh_identity"
   register: init_borg_output
   changed_when: init_borg_output.rc != 2
   failed_when: init_borg_output.rc not in [0, 2]
 
 - name: Get encryption keys
   become: true
-  ansible.builtin.command: borg key export --paper {{ storage_backup_dir }}
+  ansible.builtin.command: borg key export --paper ssh://{{ storage_backup_borg_server_user }}@{{ storage_backup_borg_server_url }}:{{ storage_backup_borg_server_port }}/{{ storage_backup_borg_server_user_home }}/{{ storage_backup_borg_repo_name }}
+  environment:
+    BORG_RSH: "'ssh -i ' ~ storage_backup_borg_ssh_identity"
   register: borg_keys
 
 - name: Print encryption keys

--- a/roles/storage_backup/templates/backup.sh.j2
+++ b/roles/storage_backup/templates/backup.sh.j2
@@ -23,13 +23,13 @@ esac; done
 if [ $OPTIND -eq 1 ]; then printf "Invalid Option: %s requires options.\nRun %s -h for help.\n" "$(basename "$0")" "$(basename "$0")" 1>&2; exit 1; fi
 shift $((OPTIND -1))
 
-export BORG_PASSPHRASE={{ storage_backup_password }}
+export BORG_PASSPHRASE="{{ storage_backup_password }}"
 
-if [ $prune = true ]; then # Prune old backups
+if [ "$prune" = true ]; then # Prune old backups
     borg prune --keep-within {{ storage_backup_retention }}d "{{ storage_backup_dir }}"
 fi
 
-if [ $storage = true ]; then # Storage Backup
+if [ "$storage" = true ]; then # Storage Backup
     borg create -C {{ storage_backup_compression }} "{{ storage_backup_dir }}::{hostname}-{now:%Y-%m-%dT%H:%M:%S}" "{{ storage_export }}"
 fi
 

--- a/roles/storage_backup/templates/backup.sh.j2
+++ b/roles/storage_backup/templates/backup.sh.j2
@@ -6,7 +6,7 @@ prune=false
 function usage {
     cat << HELP
 Usage:
-$(basename $0) [options]
+"$(basename "$0")" [options]
 
 Options:
 -s                          Perform Storage Backup.
@@ -20,7 +20,7 @@ while getopts ":sph" opt; do case ${opt} in
     p ) prune=true;;
     \? ) printf "Invalid Option: -$OPTARG\n\n" 1>&2; usage; exit 1;;
 esac; done
-if [ $OPTIND -eq 1 ]; then printf "Invalid Option: $(basename $0) requires options.\nRun $(basename $0) -h for help.\n" 1>&2; exit 1; fi
+if [ $OPTIND -eq 1 ]; then printf "Invalid Option: %s requires options.\nRun %s -h for help.\n" "$(basename "$0")" "$(basename "$0")" 1>&2; exit 1; fi
 shift $((OPTIND -1))
 
 export BORG_PASSPHRASE={{ storage_backup_password }}
@@ -30,7 +30,7 @@ if [ $prune = true ]; then # Prune old backups
 fi
 
 if [ $storage = true ]; then # Storage Backup
-    borg create -C {{ storage_backup_compression }} "{{ storage_backup_dir }}" "{{ storage_export }}"
+    borg create -C {{ storage_backup_compression }} "{{ storage_backup_dir }}::{hostname}-{now:%Y-%m-%dT%H:%M:%S}" "{{ storage_export }}"
 fi
 
 unset BORG_PASSPHRASE

--- a/roles/storage_backup/templates/backup.sh.j2
+++ b/roles/storage_backup/templates/backup.sh.j2
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+storage=false
+prune=false
+
+function usage {
+    cat << HELP
+Usage:
+$(basename $0) [options]
+
+Options:
+-s                          Perform Storage Backup.
+-p                          Prune backups older than {{ storage_backup_retention }} days
+HELP
+}
+
+while getopts ":sph" opt; do case ${opt} in
+    h ) usage; exit 0;;
+    s ) storage=true;;
+    p ) prune=true;;
+    \? ) printf "Invalid Option: -$OPTARG\n\n" 1>&2; usage; exit 1;;
+esac; done
+if [ $OPTIND -eq 1 ]; then printf "Invalid Option: $(basename $0) requires options.\nRun $(basename $0) -h for help.\n" 1>&2; exit 1; fi
+shift $((OPTIND -1))
+
+export BORG_PASSPHRASE={{ storage_backup_password }}
+
+if [ $prune = true ]; then # Prune old backups
+    borg prune --keep-within {{ storage_backup_retention }}d "{{ storage_backup_dir }}"
+fi
+
+if [ $storage = true ]; then # Storage Backup
+    borg create -C {{ storage_backup_compression }} "{{ storage_backup_dir }}" "{{ storage_export }}"
+fi
+
+unset BORG_PASSPHRASE

--- a/roles/storage_backup/templates/backup.sh.j2
+++ b/roles/storage_backup/templates/backup.sh.j2
@@ -26,11 +26,11 @@ shift $((OPTIND -1))
 export BORG_PASSPHRASE="{{ storage_backup_password }}"
 
 if [ "$prune" = true ]; then # Prune old backups
-    borg prune --keep-within {{ storage_backup_retention }}d "{{ storage_backup_dir }}"
+    borg prune --keep-within {{ storage_backup_retention }}d "ssh://{{ storage_backup_borg_server_user }}@{{ storage_backup_borg_server_url }}:{{ storage_backup_borg_server_port }}/{{ storage_backup_borg_server_user_home }}/{{ storage_backup_borg_repo_name }}"
 fi
 
 if [ "$storage" = true ]; then # Storage Backup
-    borg create -C {{ storage_backup_compression }} "{{ storage_backup_dir }}::{hostname}-{now:%Y-%m-%dT%H:%M:%S}" "{{ storage_export }}"
+    borg create -C {{ storage_backup_compression }} "ssh://{{ storage_backup_borg_server_user }}@{{ storage_backup_borg_server_url }}:{{ storage_backup_borg_server_port }}/{{ storage_backup_borg_server_user_home }}/{{ storage_backup_borg_repo_name }}::{hostname}-{now:%Y-%m-%dT%H:%M:%S}" "{{ storage_export }}"
 fi
 
 unset BORG_PASSPHRASE


### PR DESCRIPTION
This PR introduces a backup role for storage, similar to the already existing backup solution for the db.
It uses borg to keep track of backups; settings and script are similar to the db backup.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Storage Backup role: installs backup tooling, initializes a backup repository, provides a scheduled backup job, a CLI to run backups and pruning, and configurable retention, compression, and timing.

* **Documentation**
  * Added role README documenting defaults, configurable options (including passphrase behavior), and example playbook usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->