### PR TITLE
Enable text2vec-openai module and expose gRPC for Weaviate

### DIFF
--- a/roles/weaviate/templates/docker-compose.yml.j2
+++ b/roles/weaviate/templates/docker-compose.yml.j2
@@ -10,6 +10,7 @@ services:
     ports:
       - "80:80"
       - "443:443"
+      - "50051:50051"
     environment:
       - LETSENCRYPT_EMAIL=${LETSENCRYPT_EMAIL}
     volumes:
@@ -85,6 +86,15 @@ services:
       - "traefik.http.routers.weaviate-secure.middlewares=default-headers@file,rate-limit@file,default-whitelist@file"
       - "traefik.http.routers.weaviate-secure.service=weaviate"
       - "traefik.http.services.weaviate.loadbalancer.server.port=8080"
+      - "traefik.http.routers.weaviate-grpc.entrypoints=grpc"
+      - "traefik.http.routers.weaviate-grpc.rule=Host(`${WEAVIATE_DOMAIN}`)"
+      - "traefik.http.routers.weaviate-grpc.tls=true"
+      - "traefik.http.routers.weaviate-grpc.tls.certresolver=letsencrypt"
+      - "traefik.http.routers.weaviate-grpc.tls.options=default"
+      - "traefik.http.routers.weaviate-grpc.middlewares=default-whitelist@file"
+      - "traefik.http.routers.weaviate-grpc.service=weaviate-grpc"
+      - "traefik.http.services.weaviate-grpc.loadbalancer.server.port=50051"
+      - "traefik.http.services.weaviate-grpc.loadbalancer.server.scheme=h2c"
 
     deploy:
       resources:

--- a/roles/weaviate/templates/docker-compose.yml.j2
+++ b/roles/weaviate/templates/docker-compose.yml.j2
@@ -58,7 +58,7 @@ services:
       AUTHENTICATION_APIKEY_ALLOWED_KEYS: '${WEAVIATE_API_KEY}'
       AUTHENTICATION_APIKEY_USERS: '${WEAVIATE_API_USER:-{{ weaviate_api_user }}}'
       PERSISTENCE_DATA_PATH: '/var/lib/weaviate'
-      ENABLE_MODULES: 'multi2vec-clip,backup-filesystem'
+      ENABLE_MODULES: 'multi2vec-clip,text2vec-openai,backup-filesystem'
       ENABLE_API_BASED_MODULES: 'true'
       CLIP_INFERENCE_API: 'http://multi2vec-clip:8080'
       CLUSTER_HOSTNAME: 'node1'

--- a/roles/weaviate/templates/traefik.yml.j2
+++ b/roles/weaviate/templates/traefik.yml.j2
@@ -20,6 +20,9 @@ entryPoints:
   https:
     address: ":443"
 
+  grpc:
+    address: ":50051"
+
 providers:
   docker:
     endpoint: "unix:///var/run/docker.sock"


### PR DESCRIPTION
## Summary
- Adds `text2vec-openai` to `ENABLE_MODULES` in the Weaviate docker-compose template, allowing collections to use OpenAI-compatible embedding APIs (e.g. Open WebUI) for vectorization
- Exposes Weaviate's gRPC port (50051) through Traefik with TLS, enabling faster query/batch operations via the Python/TypeScript clients
- Existing `multi2vec-clip` functionality is unaffected — module selection is per-collection

## Changes
- `docker-compose.yml.j2`: Added `text2vec-openai` to modules, exposed port 50051, added gRPC Traefik router/service labels with h2c backend scheme
- `traefik.yml.j2`: Added `grpc` entrypoint on port 50051

## Test plan
- [x] Deployed to weaviate-test — container healthy, gRPC port listening
- [x] Verified gRPC health check passes (TLS, through Traefik)
- [x] Verified full Weaviate Python client connection with gRPC + auth
- [x] Confirmed `text2vec-openai` available in module list
- [ ] Deploy to weaviate-staging and weaviate-prod

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled OpenAI text-to-vector module for Weaviate, adding text vectorization support.
  * Added a secure gRPC endpoint for Weaviate (exposed on port 50051) to support gRPC clients over TLS.
  * Proxy updated to route gRPC traffic to the new listener, enabling secure, load-balanced gRPC connectivity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->