### PR TITLE
Add Weaviate configuration to Artemis application template

### DIFF
--- a/roles/artemis/defaults/main.yml
+++ b/roles/artemis/defaults/main.yml
@@ -251,6 +251,22 @@ artemis_local_llm_deployment_enabled: false
 #tum_live_base_url: "https://tum.live/api/v2"
 
 ##############################################################################
+# Weaviate Configuration
+##############################################################################
+#weaviate:
+#  enabled: true
+#  http_host:
+#  http_port: 443
+#  grpc_port: 50051
+#  scheme: https
+#  collection_prefix:
+#  vectorizer_module: text2vec-openai
+#  open_ai_embedding_model:
+#  open_ai_base_url:
+#  gpu_api_key:
+#  api_key:
+
+##############################################################################
 # Aeolus Configuration
 ##############################################################################
 #aeolus:

--- a/roles/artemis/templates/application-prod.yml.j2
+++ b/roles/artemis/templates/application-prod.yml.j2
@@ -317,6 +317,29 @@ artemis:
     secret-token: {{ nebula.secret }}
 {% endif %}
 
+{% if weaviate is defined and weaviate is not none %}
+  weaviate:
+    enabled: {{ weaviate.enabled | default(true) | lower }}
+    http-host: {{ weaviate.http_host }}
+    http-port: {{ weaviate.http_port | default(443) }}
+    grpc-port: {{ weaviate.grpc_port | default(50051) }}
+    scheme: {{ weaviate.scheme | default('https') }}
+    collection-prefix: {{ weaviate.collection_prefix | default('') }}
+    vectorizer-module: {{ weaviate.vectorizer_module | default('none') }}
+{% if weaviate.open_ai_embedding_model is defined %}
+    open-ai-embedding-model: {{ weaviate.open_ai_embedding_model }}
+{% endif %}
+{% if weaviate.open_ai_base_url is defined %}
+    open-ai-base-url: {{ weaviate.open_ai_base_url }}
+{% endif %}
+{% if weaviate.gpu_api_key is defined %}
+    gpu-api-key: {{ weaviate.gpu_api_key }}
+{% endif %}
+{% if weaviate.api_key is defined %}
+    api-key: {{ weaviate.api_key }}
+{% endif %}
+{% endif %}
+
 {% if tum_live_base_url is defined and tum_live_base_url is not none %}
   tum-live:
     api-base-url: {{ tum_live_base_url }}

--- a/roles/artemis/templates/artemis.env.j2
+++ b/roles/artemis/templates/artemis.env.j2
@@ -212,6 +212,27 @@ ARTEMIS_NEBULA_ENABLED='true'
 ARTEMIS_NEBULA_URL='{{ nebula.url }}'
 ARTEMIS_NEBULA_SECRETTOKEN='{{ nebula.secret }}'
 {% endif %}
+{% if weaviate is defined and weaviate is not none %}
+ARTEMIS_WEAVIATE_ENABLED='{{ weaviate.enabled | default(true) | lower }}'
+ARTEMIS_WEAVIATE_HTTPHOST='{{ weaviate.http_host }}'
+ARTEMIS_WEAVIATE_HTTPPORT='{{ weaviate.http_port | default(443) }}'
+ARTEMIS_WEAVIATE_GRPCPORT='{{ weaviate.grpc_port | default(50051) }}'
+ARTEMIS_WEAVIATE_SCHEME='{{ weaviate.scheme | default("https") }}'
+ARTEMIS_WEAVIATE_COLLECTIONPREFIX='{{ weaviate.collection_prefix | default("") }}'
+ARTEMIS_WEAVIATE_VECTORIZERMODULE='{{ weaviate.vectorizer_module | default("none") }}'
+{% if weaviate.open_ai_embedding_model is defined %}
+ARTEMIS_WEAVIATE_OPENAIEMBEDDINGMODEL='{{ weaviate.open_ai_embedding_model }}'
+{% endif %}
+{% if weaviate.open_ai_base_url is defined %}
+ARTEMIS_WEAVIATE_OPENAIBASEURL='{{ weaviate.open_ai_base_url }}'
+{% endif %}
+{% if weaviate.gpu_api_key is defined %}
+ARTEMIS_WEAVIATE_GPUAPIKEY='{{ weaviate.gpu_api_key }}'
+{% endif %}
+{% if weaviate.api_key is defined %}
+ARTEMIS_WEAVIATE_APIKEY='{{ weaviate.api_key }}'
+{% endif %}
+{% endif %}
 {% if tum_live_base_url is defined and tum_live_base_url is not none %}
 ARTEMIS_TUMLIVE_APIBASEURL='{{ tum_live_base_url }}'
 {% endif %}


### PR DESCRIPTION
## Summary
- Add `weaviate` block to `application-prod.yml.j2` template with all properties from `WeaviateConfigurationProperties`
- Add commented Weaviate defaults to `roles/artemis/defaults/main.yml`
- Supports connection settings (host, ports, scheme), text2vec-openai vectorizer config (embedding model, base URL, GPU API key via Logos proxy), and optional Weaviate server API key authentication

## Context
Artemis needs to connect to Weaviate for vector search. The Weaviate servers are already deployed (test/staging/prod). This PR adds the template support so that the connection parameters can be configured per environment via group_vars in `artemis-ansible`.

Companion PR: https://github.com/ls1intum/artemis-ansible/pull/new/feat/weaviate-artemis-config

## Test plan
- [ ] Verify rendered `application-prod.yml` has correct YAML indentation and kebab-case property names
- [ ] Verify Jinja2 conditionals: weaviate block only rendered when `weaviate` var is defined
- [ ] Verify optional fields (`open_ai_embedding_model`, `open_ai_base_url`, `gpu_api_key`, `api_key`) only rendered when defined

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Weaviate vector database configuration, including connection settings (host, ports, scheme), collection prefix, and vectorizer module options.
  * Optional API key and OpenAI embedding model settings are now configurable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->