### PR TITLE
Enable deimos test deployment artemis ansible collection

### DIFF
--- a/roles/artemis/defaults/main.yml
+++ b/roles/artemis/defaults/main.yml
@@ -270,6 +270,17 @@ artemis_local_llm_deployment_enabled: false
 #  api_key:
 
 ##############################################################################
+# Deimos Configuration
+##############################################################################
+# deimos:
+#   llm:
+#     base_url: https://gpu.aet.cit.tum.de
+#     api_key: 
+#     model: openai/gpt-oss-120b
+#     completions_path: /api/chat/completions
+#     temperature: 0.3
+
+##############################################################################
 # Aeolus Configuration
 ##############################################################################
 #aeolus:

--- a/roles/artemis/defaults/main.yml
+++ b/roles/artemis/defaults/main.yml
@@ -275,7 +275,7 @@ artemis_local_llm_deployment_enabled: false
 # deimos:
 #   llm:
 #     base_url: https://gpu.aet.cit.tum.de
-#     api_key: 
+#     api_key:
 #     model: openai/gpt-oss-120b
 #     completions_path: /api/chat/completions
 #     temperature: 0.3

--- a/roles/artemis/templates/application-prod.yml.j2
+++ b/roles/artemis/templates/application-prod.yml.j2
@@ -345,6 +345,17 @@ artemis:
 {% endif %}
 {% endif %}
 
+{% if deimos is defined %}
+  deimos:
+    enabled: true
+    llm:
+      base-url: {{ deimos.llm.base_url }}
+      api-key: {{ deimos.llm.api_key }}
+      model: {{ deimos.llm.model }}
+      completions-path: {{ deimos.llm.completions_path }}
+      temperature: {{ deimos.llm.temperature }}
+{% endif %}
+
 {% if tum_live_base_url is defined and tum_live_base_url is not none %}
   tum-live:
     api-base-url: {{ tum_live_base_url }}

--- a/roles/artemis/templates/artemis.env.j2
+++ b/roles/artemis/templates/artemis.env.j2
@@ -237,6 +237,16 @@ ARTEMIS_WEAVIATE_GPUAPIKEY='{{ weaviate.gpu_api_key }}'
 ARTEMIS_WEAVIATE_APIKEY='{{ weaviate.api_key }}'
 {% endif %}
 {% endif %}
+
+{% if deimos is defined %}
+ARTEMIS_DEIMOS_ENABLED='true'
+ARTEMIS_DEIMOS_LLM_BASEURL='{{ deimos.llm.base_url }}'
+ARTEMIS_DEIMOS_LLM_APIKEY='{{ deimos.llm.api_key }}'
+ARTEMIS_DEIMOS_LLM_MODEL='{{ deimos.llm.model }}'
+ARTEMIS_DEIMOS_LLM_COMPLETIONSPATH='{{ deimos.llm.completions_path }}'
+ARTEMIS_DEIMOS_LLM_TEMPERATURE='{{ deimos.llm.temperature }}'
+{% endif %}
+
 {% if tum_live_base_url is defined and tum_live_base_url is not none %}
 ARTEMIS_TUMLIVE_APIBASEURL='{{ tum_live_base_url }}'
 {% endif %}


### PR DESCRIPTION
Config changes on artemis-ansible-collection for deployment on artemis test server for the following new artemis feature: https://github.com/ls1intum/Artemis/pull/12552

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional Deimos LLM integration configuration. Users can now define LLM endpoint parameters including base URL, API key, model name, completions path, and temperature settings to enable optional language model support in the application environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->