### PR TITLE
`Development`: Add listen for ssh git stream proxy for ipv6

### DIFF
--- a/roles/proxy/tasks/nginx.yml
+++ b/roles/proxy/tasks/nginx.yml
@@ -127,6 +127,7 @@
         }
         server {
           listen 7921;
+          listen [::]:7921;
           proxy_pass artemis_ssh;
         }
       }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added IPv6 support to the SSH proxy service, enabling connections over IPv6 alongside IPv4.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->