### PR TITLE
Support 2-segment Artemis release tags (e.g. 9.2)

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -2,7 +2,7 @@
 namespace: ls1intum
 name: artemis
 
-version: 2.4.0
+version: 2.5.0
 
 readme: README.md
 

--- a/roles/artemis/README.md
+++ b/roles/artemis/README.md
@@ -6,6 +6,16 @@ This role installs Artemis on a host. The role supports single node installation
 
 Default variables can be found in the `defaults/main.yml` file.
 
+### `artemis_version`
+
+The deployed Artemis version. Accepted values:
+
+- A [GitHub release tag](https://github.com/ls1intum/Artemis/releases) — either 3-segment (`9.1.2`) or 2-segment (`9.2`). The role downloads the matching `Artemis.war` from the GitHub release.
+- An absolute path to a local `Artemis.war` (e.g. `/home/user/Artemis.war`). The role rsyncs it onto the target host.
+- For Docker-based deployments (`use_docker: true`), the same string is used as the `ghcr.io/ls1intum/artemis:<tag>` image tag.
+
+> **YAML quoting:** when recording a 2-segment version in YAML (`group_vars`, `host_vars`, JSON/YAML extra-vars), always quote it: `artemis_version: "9.2"`. Without quotes YAML parses `9.2` as a float, and values like `9.10` silently become `9.1`. The role asserts the value is a string at entry time and fails fast otherwise.
+
 ### Variables that have to be configured for a single node installation:
 
 ```

--- a/roles/artemis/tasks/copy_artemis_executable.yml
+++ b/roles/artemis/tasks/copy_artemis_executable.yml
@@ -11,7 +11,7 @@
 
 - name: Check if version matches release pattern
   set_fact:
-    is_release: "{{ artemis_version is match('^\\d+\\.\\d+\\.\\d+$') }}"
+    is_release: "{{ artemis_version is match('^[0-9]+\\.[0-9]+(?:\\.[0-9]+)?\\Z') }}"
 
 - name: "Copying Artemis.war to {{ artemis_working_directory }}/artemis.war.new ..."
   debug:

--- a/roles/artemis/tasks/main.yml
+++ b/roles/artemis/tasks/main.yml
@@ -1,4 +1,35 @@
 ---
+# Catch unquoted 2-segment YAML floats (e.g. `artemis_version: 9.2` → float, `9.10` → 9.1)
+# before they reach the WAR URL, the Docker tag, or the helper script's tag argument.
+- name: Assert artemis_version is a string when set
+  ansible.builtin.assert:
+    that:
+      - artemis_version is string
+    fail_msg: >-
+      artemis_version is not a string (got type {{ artemis_version | type_debug }},
+      value {{ artemis_version }}). In YAML inventory/group_vars (or JSON/YAML
+      extra-vars), 2-segment release tags like 9.2 must be quoted ("9.2") —
+      otherwise they parse as floats and "9.10" silently becomes "9.1".
+  when:
+    - artemis_version is defined
+    - artemis_version is not none
+    - artemis_version != ""
+
+- name: Assert artemis_build_version is a string when overridden
+  ansible.builtin.assert:
+    that:
+      - artemis_build_version is string
+    fail_msg: >-
+      artemis_build_version is not a string (got type
+      {{ artemis_build_version | type_debug }}, value {{ artemis_build_version }}).
+      Same YAML-float footgun as artemis_version: in group_vars/host_vars or
+      inline JSON/YAML-form extra-vars, 2-segment Docker tags must be quoted
+      (e.g. "9.2").
+  when:
+    - artemis_build_version is defined
+    - artemis_build_version is not none
+    - artemis_build_version != ""
+
 # Check if variables are set correctly
 - include_tasks: variable_checks.yml
   when: (setup_system | bool) or (update_artemis_config | bool)

--- a/roles/mysqld_exporter/tasks/main.yml
+++ b/roles/mysqld_exporter/tasks/main.yml
@@ -6,7 +6,7 @@
     fail_msg: "You must set the mysql_exporter_password variable"
 
 - name: Create database user with password and PROCESS, REPLICATION CLIENT privileges
-  community.mysql.mysql_user:
+  ansible.mysql.mysql_user:
     name: "{{ mysql_exporter_user }}"
     password: "{{ mysql_exporter_password }}"
     priv: "*.*:PROCESS,REPLICATION CLIENT"


### PR DESCRIPTION
## Summary

- Loosen the `is_release` regex in `copy_artemis_executable.yml` from `^\d+\.\d+\.\d+$` to `^[0-9]+\.[0-9]+(?:\.[0-9]+)?\Z` so 2-segment GitHub release tags like `9.2` are recognised as releases instead of falling through to the local-path branch (`ansible.posix.synchronize`).
- Assert at role entry that `artemis_version` / `artemis_build_version` are strings when set, to fail fast on the unquoted YAML float footgun (`artemis_version: 9.2` unquoted in YAML parses as a float; `9.10` silently becomes `9.1`).
- Document the variable contract in `roles/artemis/README.md`.
- Bump the collection to `2.5.0`.

The native WAR path is the only path with regex-based parsing. The Docker test-server path always interpolated the version into the image tag directly, so the regex fix isn't needed there — but the string-assert protects both paths.

Companion PR in `artemis-ansible` (consumer): https://github.com/ls1intum/artemis-ansible (separate PR will be linked).

## Why

Releases since 9.2 use the 2-segment `major.minor` tag scheme. Deploying `9.2` previously caused `ansible.posix.synchronize` to fail because the value was treated as a local rsync source.

## Test plan

- [ ] `ansible-lint roles/artemis/tasks/copy_artemis_executable.yml roles/artemis/tasks/main.yml` passes (verified locally).
- [ ] `ansible-lint` full repo passes; only the pre-existing `roles/mysqld_exporter` fqcn[canonical] finding on `main` remains (unrelated).
- [ ] After installing the collection in `artemis-ansible`, `ansible-playbook playbooks/artemis-staging2/nodes-version-update.yml -e artemis_version=9.2 --diff --check` exercises the release path (was failing on `main`).
- [ ] Assert fires on `-e '{"artemis_version": 9.2}'` (JSON form, parsed as float) with the documented error message.
- [ ] Assert does NOT fire when `artemis_version` is unset/null (version-update playbook entry).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Extended version format validation to accept both 2-segment and 3-segment version numbers.

* **Documentation**
  * Enhanced documentation on version specification requirements and YAML quoting best practices.

* **Chores**
  * Collection version updated to 2.5.0.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ls1intum/artemis-ansible-collection/pull/203)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->