### PR TITLE
feat: reuse Artemis checkout for Docker test-server deployments

### DIFF
--- a/roles/artemis/templates/artemis-docker.sh.j2
+++ b/roles/artemis/templates/artemis-docker.sh.j2
@@ -31,13 +31,32 @@ function update_artemis_checkout {
     local pr_branch=$1
 
     if [ ! -d "$ARTEMIS_REPO_DIR/.git" ]; then
-        rm -rf "$ARTEMIS_REPO_DIR"
-        git clone --depth 1 --branch "$pr_branch" https://github.com/ls1intum/Artemis.git "$ARTEMIS_REPO_DIR"
+        if ! rm -rf "$ARTEMIS_REPO_DIR"; then
+            echo "Failed to remove ARTEMIS_REPO_DIR='$ARTEMIS_REPO_DIR' before cloning branch '$pr_branch'" 1>&2
+            return 1
+        fi
+        if ! git clone --depth 1 --branch "$pr_branch" https://github.com/ls1intum/Artemis.git "$ARTEMIS_REPO_DIR"; then
+            echo "Failed to clone branch '$pr_branch' into ARTEMIS_REPO_DIR='$ARTEMIS_REPO_DIR'" 1>&2
+            rm -rf "$ARTEMIS_REPO_DIR"
+            return 1
+        fi
     else
-        git -C "$ARTEMIS_REPO_DIR" fetch --depth 1 origin "+refs/heads/$pr_branch:refs/remotes/origin/$pr_branch"
-        git -C "$ARTEMIS_REPO_DIR" checkout --detach "origin/$pr_branch"
-        git -C "$ARTEMIS_REPO_DIR" reset --hard "origin/$pr_branch"
-        git -C "$ARTEMIS_REPO_DIR" clean -fd
+        if ! git -C "$ARTEMIS_REPO_DIR" fetch --depth 1 origin "+refs/heads/${pr_branch}:refs/remotes/origin/${pr_branch}"; then
+            echo "Failed to fetch branch '$pr_branch' in ARTEMIS_REPO_DIR='$ARTEMIS_REPO_DIR'" 1>&2
+            return 1
+        fi
+        if ! git -C "$ARTEMIS_REPO_DIR" checkout --detach "origin/$pr_branch"; then
+            echo "Failed to checkout branch '$pr_branch' in ARTEMIS_REPO_DIR='$ARTEMIS_REPO_DIR'" 1>&2
+            return 1
+        fi
+        if ! git -C "$ARTEMIS_REPO_DIR" reset --hard "origin/$pr_branch"; then
+            echo "Failed to reset branch '$pr_branch' in ARTEMIS_REPO_DIR='$ARTEMIS_REPO_DIR'" 1>&2
+            return 1
+        fi
+        if ! git -C "$ARTEMIS_REPO_DIR" clean -fd; then
+            echo "Failed to clean branch '$pr_branch' in ARTEMIS_REPO_DIR='$ARTEMIS_REPO_DIR'" 1>&2
+            return 1
+        fi
     fi
 }
 
@@ -46,8 +65,11 @@ function start {
     local pr_branch=$2
 
     echo "Starting Artemis with PR tag: $pr_tag and branch: $pr_branch"
-    update_artemis_checkout "$pr_branch"
-    sed -i "s/ARTEMIS_DOCKER_TAG=.*/ARTEMIS_DOCKER_TAG='$pr_tag'/g" $ENV_FILE
+    if ! update_artemis_checkout "$pr_branch"; then
+        echo "update_artemis_checkout failed for branch '$pr_branch'; aborting start deployment" 1>&2
+        exit 1
+    fi
+    sed -i "s/ARTEMIS_DOCKER_TAG=.*/ARTEMIS_DOCKER_TAG='$pr_tag'/g" "$ENV_FILE"
     docker compose --project-directory "$PROJECT_DIR" -f "$PROJECT_DIR/$COMPOSE_FILE" --env-file "$DOCKER_IMAGE_ENV_FILE" --env-file "$ENV_FILE" up -d --pull always --no-build --remove-orphans
     
     # Reload Nginx configuration as Nginx may still be running from a previous start. This is necessary to apply the new configuration.

--- a/roles/artemis/templates/artemis-docker.sh.j2
+++ b/roles/artemis/templates/artemis-docker.sh.j2
@@ -1,12 +1,13 @@
 #!/bin/bash
 
-PROJECT_DIR="{{ artemis_working_directory }}/Artemis/docker"
+ARTEMIS_REPO_DIR="{{ artemis_working_directory }}/Artemis"
+PROJECT_DIR="$ARTEMIS_REPO_DIR/docker"
 {% set default_compose_file = "test-server-" + artemis_database_type + ".yml" %}
 {% set localci_compose_file = "test-server-" + artemis_database_type + "-localci.yml" %}
 {% set multi_node_compose_file = "test-server-multi-node-" + artemis_database_type + "-localci.yml" %}
 
 COMPOSE_FILE="{% if is_multinode_install is defined and is_multinode_install %}{{ multi_node_compose_file }}{% elif continuous_integration.localci is defined %}{{ localci_compose_file }}{% else %}{{ default_compose_file }}{% endif %}"
-DOCKER_IMAGE_ENV_FILE="{{ artemis_working_directory }}/Artemis/.env"
+DOCKER_IMAGE_ENV_FILE="$ARTEMIS_REPO_DIR/.env"
 ENV_FILE="{{ artemis_working_directory }}/docker.env"
 {% if continuous_integration.localci is defined %}
 export DOCKER_GROUP_ID=$(getent group docker | cut -d: -f3)
@@ -26,13 +27,26 @@ Commands:
 HELP
 }
 
+function update_artemis_checkout {
+    local pr_branch=$1
+
+    if [ ! -d "$ARTEMIS_REPO_DIR/.git" ]; then
+        rm -rf "$ARTEMIS_REPO_DIR"
+        git clone --depth 1 --branch "$pr_branch" https://github.com/ls1intum/Artemis.git "$ARTEMIS_REPO_DIR"
+    else
+        git -C "$ARTEMIS_REPO_DIR" fetch --depth 1 origin "+refs/heads/$pr_branch:refs/remotes/origin/$pr_branch"
+        git -C "$ARTEMIS_REPO_DIR" checkout --detach "origin/$pr_branch"
+        git -C "$ARTEMIS_REPO_DIR" reset --hard "origin/$pr_branch"
+        git -C "$ARTEMIS_REPO_DIR" clean -fd
+    fi
+}
+
 function start {
     local pr_tag=$1
     local pr_branch=$2
 
     echo "Starting Artemis with PR tag: $pr_tag and branch: $pr_branch"
-    rm -rf Artemis
-    git clone https://github.com/ls1intum/Artemis.git -b "$pr_branch" Artemis
+    update_artemis_checkout "$pr_branch"
     sed -i "s/ARTEMIS_DOCKER_TAG=.*/ARTEMIS_DOCKER_TAG='$pr_tag'/g" $ENV_FILE
     docker compose --project-directory "$PROJECT_DIR" -f "$PROJECT_DIR/$COMPOSE_FILE" --env-file "$DOCKER_IMAGE_ENV_FILE" --env-file "$ENV_FILE" up -d --pull always --no-build --remove-orphans
     


### PR DESCRIPTION
### Motivation

Docker-based test-server deployments currently delete and reclone the Artemis repository on every deployment. This adds avoidable checkout time even when a valid checkout already exists on the server.

### Description

This PR updates the Docker deployment script template to reuse the existing Artemis checkout under `{{ artemis_working_directory }}/Artemis`.

Changes:
- Introduces `ARTEMIS_REPO_DIR` and derives Docker paths from it.
- Adds `update_artemis_checkout` to either:
  - clone the target branch when no valid git checkout exists, or
  - fetch, detach-checkout, reset, and clean the existing checkout.
- Replaces the unconditional `rm -rf Artemis` and `git clone` flow in `start`.
- Leaves Docker Compose commands, app-only restart behavior, nginx reload behavior, and health behavior unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Reduced deployment startup time by intelligently reusing existing repository installations instead of always performing full fresh clones.

* **Infrastructure Improvements**
  * Enhanced repository update mechanisms with optimized Git operations for more efficient branch management and synchronization during deployments.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ls1intum/artemis-ansible-collection/pull/205?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->