### PR TITLE
feat: pull only Artemis app images during Docker test-server deploys

### DIFF
--- a/roles/artemis/templates/artemis-docker.sh.j2
+++ b/roles/artemis/templates/artemis-docker.sh.j2
@@ -27,13 +27,23 @@ HELP
 }
 
 function get_artemis_services {
-    docker compose --project-directory "$PROJECT_DIR" -f "$PROJECT_DIR/$COMPOSE_FILE" --env-file "$DOCKER_IMAGE_ENV_FILE" --env-file "$ENV_FILE" config --services | grep "^artemis-app"
+    local services
+    local docker_compose_exit_code
+
+    services=$(docker compose --project-directory "$PROJECT_DIR" -f "$PROJECT_DIR/$COMPOSE_FILE" --env-file "$DOCKER_IMAGE_ENV_FILE" --env-file "$ENV_FILE" config --services)
+    docker_compose_exit_code=$?
+    if [ "$docker_compose_exit_code" -ne 0 ]; then
+        return "$docker_compose_exit_code"
+    fi
+
+    echo "$services" | grep "^artemis-app" || true
 }
 
 function start {
     local pr_tag=$1
     local pr_branch=$2
     local artemis_services
+    local get_artemis_services_exit_code
 
     echo "Starting Artemis with PR tag: $pr_tag and branch: $pr_branch"
     rm -rf Artemis
@@ -41,6 +51,11 @@ function start {
     sed -i "s/ARTEMIS_DOCKER_TAG=.*/ARTEMIS_DOCKER_TAG='$pr_tag'/g" "$ENV_FILE"
 
     artemis_services=$(get_artemis_services)
+    get_artemis_services_exit_code=$?
+    if [ "$get_artemis_services_exit_code" -ne 0 ]; then
+        exit "$get_artemis_services_exit_code"
+    fi
+
     if [ -z "$artemis_services" ]; then
         echo "No Artemis app services found in $COMPOSE_FILE" 1>&2
         exit 1

--- a/roles/artemis/templates/artemis-docker.sh.j2
+++ b/roles/artemis/templates/artemis-docker.sh.j2
@@ -26,15 +26,28 @@ Commands:
 HELP
 }
 
+function get_artemis_services {
+    docker compose --project-directory "$PROJECT_DIR" -f "$PROJECT_DIR/$COMPOSE_FILE" --env-file "$DOCKER_IMAGE_ENV_FILE" --env-file "$ENV_FILE" config --services | grep "^artemis-app"
+}
+
 function start {
     local pr_tag=$1
     local pr_branch=$2
+    local artemis_services
 
     echo "Starting Artemis with PR tag: $pr_tag and branch: $pr_branch"
     rm -rf Artemis
     git clone https://github.com/ls1intum/Artemis.git -b "$pr_branch" Artemis
-    sed -i "s/ARTEMIS_DOCKER_TAG=.*/ARTEMIS_DOCKER_TAG='$pr_tag'/g" $ENV_FILE
-    docker compose --project-directory "$PROJECT_DIR" -f "$PROJECT_DIR/$COMPOSE_FILE" --env-file "$DOCKER_IMAGE_ENV_FILE" --env-file "$ENV_FILE" up -d --pull always --no-build --remove-orphans
+    sed -i "s/ARTEMIS_DOCKER_TAG=.*/ARTEMIS_DOCKER_TAG='$pr_tag'/g" "$ENV_FILE"
+
+    artemis_services=$(get_artemis_services)
+    if [ -z "$artemis_services" ]; then
+        echo "No Artemis app services found in $COMPOSE_FILE" 1>&2
+        exit 1
+    fi
+
+    docker compose --project-directory "$PROJECT_DIR" -f "$PROJECT_DIR/$COMPOSE_FILE" --env-file "$DOCKER_IMAGE_ENV_FILE" --env-file "$ENV_FILE" pull $artemis_services
+    docker compose --project-directory "$PROJECT_DIR" -f "$PROJECT_DIR/$COMPOSE_FILE" --env-file "$DOCKER_IMAGE_ENV_FILE" --env-file "$ENV_FILE" up -d --no-build --remove-orphans
     
     # Reload Nginx configuration as Nginx may still be running from a previous start. This is necessary to apply the new configuration.
     docker compose --project-directory "$PROJECT_DIR" -f "$PROJECT_DIR/$COMPOSE_FILE" --env-file "$DOCKER_IMAGE_ENV_FILE" --env-file "$ENV_FILE" exec nginx nginx -s reload || true

--- a/roles/artemis/templates/artemis-docker.sh.j2
+++ b/roles/artemis/templates/artemis-docker.sh.j2
@@ -46,7 +46,11 @@ function start {
         exit 1
     fi
 
-    docker compose --project-directory "$PROJECT_DIR" -f "$PROJECT_DIR/$COMPOSE_FILE" --env-file "$DOCKER_IMAGE_ENV_FILE" --env-file "$ENV_FILE" pull $artemis_services
+    if ! docker compose --project-directory "$PROJECT_DIR" -f "$PROJECT_DIR/$COMPOSE_FILE" --env-file "$DOCKER_IMAGE_ENV_FILE" --env-file "$ENV_FILE" pull $artemis_services; then
+        echo "Failed to pull Artemis services ($artemis_services) using compose file $COMPOSE_FILE" 1>&2
+        exit 1
+    fi
+
     docker compose --project-directory "$PROJECT_DIR" -f "$PROJECT_DIR/$COMPOSE_FILE" --env-file "$DOCKER_IMAGE_ENV_FILE" --env-file "$ENV_FILE" up -d --no-build --remove-orphans
     
     # Reload Nginx configuration as Nginx may still be running from a previous start. This is necessary to apply the new configuration.

--- a/roles/artemis/templates/artemis-docker.sh.j2
+++ b/roles/artemis/templates/artemis-docker.sh.j2
@@ -27,7 +27,21 @@ HELP
 }
 
 function get_artemis_services {
-    docker compose --project-directory "$PROJECT_DIR" -f "$PROJECT_DIR/$COMPOSE_FILE" --env-file "$DOCKER_IMAGE_ENV_FILE" --env-file "$ENV_FILE" config --services | grep "^artemis-app"
+    local stderr_file=$(mktemp)
+    local services
+
+    services=$(docker compose --project-directory "$PROJECT_DIR" -f "$PROJECT_DIR/$COMPOSE_FILE" --env-file "$DOCKER_IMAGE_ENV_FILE" --env-file "$ENV_FILE" config --services 2>"$stderr_file")
+    local exit_code=$?
+
+    if [ $exit_code -ne 0 ]; then
+        echo "Failed to retrieve docker compose configuration:" 1>&2
+        cat "$stderr_file" 1>&2
+        rm -f "$stderr_file"
+        return $exit_code
+    fi
+
+    rm -f "$stderr_file"
+    echo "$services" | grep "^artemis-app"
 }
 
 function start {


### PR DESCRIPTION
### Motivation

Docker test-server deployments currently run `docker compose up --pull always` for the full compose project. This can trigger unnecessary image checks or pulls for stable infrastructure services such as nginx, database, registry, and broker, even though only the Artemis app image changes per PR deployment.

### Description

This PR narrows the forced image pull to Artemis app services only.

Changes:
- Detects Artemis app services dynamically via `docker compose config --services`.
- Supports both single-node `artemis-app` and multi-node `artemis-app-node-*` deployments.
- Pulls only the detected Artemis app services before startup.
- Keeps the full-stack `docker compose up -d --no-build --remove-orphans` behavior so missing or stopped infrastructure services can still be recovered.
- Leaves the existing checkout and nginx reload behavior unchanged.

### Testing Instructions

#### Prerequisites:

- A Docker-based Artemis test server deployment.
- Access to deploy a PR image tag and branch.

#### Flow:

1. Deploy a branch to a single-node test server and verify the Artemis app starts successfully.
2. Confirm the deployment pulls only the Artemis app service image explicitly.
3. Deploy to a multi-node test server and verify all `artemis-app-node-*` services are detected and pulled.
4. Stop or remove nginx before deployment and verify the full-stack `up` still recreates or restarts it.
5. Confirm the Artemis app remains reachable through nginx after deployment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Automatically discover and validate application services before startup; exit with an error if none are found.
  * Fetch images only for the discovered application services to reduce unnecessary network activity.
  * Start the compose stack so it skips implicit rebuilds and removes orphaned containers, yielding cleaner and more predictable deployments.
  * Improve failure behavior when the compose configuration cannot be retrieved.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ls1intum/artemis-ansible-collection/pull/206?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->