### PR TITLE
feat: start dependent test-server nodes after initial node starts

### DIFF
--- a/roles/artemis/tasks/docker_deploy_artemis.yml
+++ b/roles/artemis/tasks/docker_deploy_artemis.yml
@@ -124,3 +124,17 @@
     group: "{{ artemis_user_group }}"
     mode: "770"
   notify: restart docker artemis
+
+- name: Copy test server multi-node started dependencies compose override
+  become: true
+  template:
+    src: "templates/test-server-multi-node-started-dependencies.yml.j2"
+    dest: "{{ artemis_working_directory }}/test-server-multi-node-started-dependencies.yml"
+    owner: "{{ artemis_user_name }}"
+    group: "{{ artemis_user_group }}"
+    mode: "660"
+  when:
+    - is_testserver | bool
+    - is_multinode_install | bool
+    - (artemis_node_count | int) == 3
+  notify: restart docker artemis

--- a/roles/artemis/templates/artemis-docker.sh.j2
+++ b/roles/artemis/templates/artemis-docker.sh.j2
@@ -4,13 +4,21 @@ PROJECT_DIR="{{ artemis_working_directory }}/Artemis/docker"
 {% set default_compose_file = "test-server-" + artemis_database_type + ".yml" %}
 {% set localci_compose_file = "test-server-" + artemis_database_type + "-localci.yml" %}
 {% set multi_node_compose_file = "test-server-multi-node-" + artemis_database_type + "-localci.yml" %}
+{% set use_testserver_started_dependencies = is_testserver is defined and (is_testserver | bool) and is_multinode_install is defined and (is_multinode_install | bool) and (artemis_node_count | int) == 3 %}
 
 COMPOSE_FILE="{% if is_multinode_install is defined and is_multinode_install %}{{ multi_node_compose_file }}{% elif continuous_integration.localci is defined %}{{ localci_compose_file }}{% else %}{{ default_compose_file }}{% endif %}"
+COMPOSE_OVERRIDE_FILE="{% if use_testserver_started_dependencies %}{{ artemis_working_directory }}/test-server-multi-node-started-dependencies.yml{% endif %}"
 DOCKER_IMAGE_ENV_FILE="{{ artemis_working_directory }}/Artemis/.env"
 ENV_FILE="{{ artemis_working_directory }}/docker.env"
 {% if continuous_integration.localci is defined %}
 export DOCKER_GROUP_ID=$(getent group docker | cut -d: -f3)
 {% endif %}
+
+COMPOSE_ARGS=(-f "$PROJECT_DIR/$COMPOSE_FILE")
+if [ -n "$COMPOSE_OVERRIDE_FILE" ]; then
+    COMPOSE_ARGS+=(-f "$COMPOSE_OVERRIDE_FILE")
+fi
+ENV_ARGS=(--env-file "$DOCKER_IMAGE_ENV_FILE" --env-file "$ENV_FILE")
 
 # Function: Print general usage information
 function general_help {
@@ -34,10 +42,10 @@ function start {
     rm -rf Artemis
     git clone https://github.com/ls1intum/Artemis.git -b "$pr_branch" Artemis
     sed -i "s/ARTEMIS_DOCKER_TAG=.*/ARTEMIS_DOCKER_TAG='$pr_tag'/g" $ENV_FILE
-    docker compose --project-directory "$PROJECT_DIR" -f "$PROJECT_DIR/$COMPOSE_FILE" --env-file "$DOCKER_IMAGE_ENV_FILE" --env-file "$ENV_FILE" up -d --pull always --no-build --remove-orphans
+    docker compose --project-directory "$PROJECT_DIR" "${COMPOSE_ARGS[@]}" "${ENV_ARGS[@]}" up -d --pull always --no-build --remove-orphans
     
     # Reload Nginx configuration as Nginx may still be running from a previous start. This is necessary to apply the new configuration.
-    docker compose --project-directory "$PROJECT_DIR" -f "$PROJECT_DIR/$COMPOSE_FILE" --env-file "$DOCKER_IMAGE_ENV_FILE" --env-file "$ENV_FILE" exec nginx nginx -s reload || true
+    docker compose --project-directory "$PROJECT_DIR" "${COMPOSE_ARGS[@]}" "${ENV_ARGS[@]}" exec nginx nginx -s reload || true
 }
 
 function stop {
@@ -46,10 +54,10 @@ function stop {
     echo "Stopping Artemis"
 
     # Get all docker-compose services that are not called nginx.
-    services=$(docker compose --project-directory "$PROJECT_DIR" -f "$PROJECT_DIR/$COMPOSE_FILE" --env-file "$DOCKER_IMAGE_ENV_FILE" --env-file "$ENV_FILE" ps --services)
+    services=$(docker compose --project-directory "$PROJECT_DIR" "${COMPOSE_ARGS[@]}" "${ENV_ARGS[@]}" ps --services)
     artemis_services=$(echo "$services" | grep -v "^nginx")
 
-    docker compose --project-directory "$PROJECT_DIR" -f "$PROJECT_DIR/$COMPOSE_FILE" --env-file "$DOCKER_IMAGE_ENV_FILE" --env-file "$ENV_FILE" stop $artemis_services
+    docker compose --project-directory "$PROJECT_DIR" "${COMPOSE_ARGS[@]}" "${ENV_ARGS[@]}" stop $artemis_services
 }
 
 function restart {
@@ -59,18 +67,18 @@ function restart {
 
 function artemis_logs {
     # Get all docker-compose services matching artemis-app* to be multi-node and single-node compatible.
-    services=$(docker compose --project-directory "$PROJECT_DIR" -f "$PROJECT_DIR/$COMPOSE_FILE" --env-file "$DOCKER_IMAGE_ENV_FILE" --env-file "$ENV_FILE" ps --services)
+    services=$(docker compose --project-directory "$PROJECT_DIR" "${COMPOSE_ARGS[@]}" "${ENV_ARGS[@]}" ps --services)
     artemis_services=$(echo "$services" | grep "^artemis-app")
 
-    docker compose --project-directory "$PROJECT_DIR" -f "$PROJECT_DIR/$COMPOSE_FILE" --env-file "$DOCKER_IMAGE_ENV_FILE" --env-file "$ENV_FILE" logs -f $artemis_services
+    docker compose --project-directory "$PROJECT_DIR" "${COMPOSE_ARGS[@]}" "${ENV_ARGS[@]}" logs -f $artemis_services
 }
 
 function all_logs {
-    docker compose --project-directory "$PROJECT_DIR" -f "$PROJECT_DIR/$COMPOSE_FILE" --env-file "$DOCKER_IMAGE_ENV_FILE" --env-file "$ENV_FILE" logs -f
+    docker compose --project-directory "$PROJECT_DIR" "${COMPOSE_ARGS[@]}" "${ENV_ARGS[@]}" logs -f
 }
 
 function run_docker_compose_cmd {
-    docker compose --project-directory "$PROJECT_DIR" -f "$PROJECT_DIR/$COMPOSE_FILE" --env-file "$DOCKER_IMAGE_ENV_FILE" --env-file "$ENV_FILE" "$@"
+    docker compose --project-directory "$PROJECT_DIR" "${COMPOSE_ARGS[@]}" "${ENV_ARGS[@]}" "$@"
 }
 
 # read subcommand `artemis-docker subcommand server` in variable and remove base command from argument list

--- a/roles/artemis/templates/test-server-multi-node-started-dependencies.yml.j2
+++ b/roles/artemis/templates/test-server-multi-node-started-dependencies.yml.j2
@@ -1,0 +1,9 @@
+# {{ ansible_managed }}
+
+services:
+{% for node_id in range(2, artemis_node_count + 1) %}
+  artemis-app-node-{{ node_id }}:
+    depends_on:
+      artemis-app-node-1:
+        condition: service_started
+{% endfor %}


### PR DESCRIPTION
### Motivation

Three-node test-server deployments currently wait until the initial Artemis node is healthy before starting the remaining nodes. This slows down test-server deployments because the other nodes can already start once the initial node container has started.

### Description

- Add a test-server-only Docker Compose override for three-node multi-node deployments.
- Change only the dependency from `artemis-app-node-2` / `artemis-app-node-3` to `artemis-app-node-1` from `service_healthy` to `service_started`.
- Keep the existing health waits for database, registry, and broker services unchanged.
- Wire the override into `artemis-docker.sh` only when `is_testserver`, `is_multinode_install`, and `artemis_node_count == 3`.

### Testing Instructions

#### Prerequisites:

A three-node Docker-based Artemis test-server inventory with:

```is_testserver: true
use_docker: true
is_multinode_install: true
artemis_node_count: 3
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for 3-node Artemis test server multi-node configurations with proper node dependency management in Docker deployments.

* **Refactor**
  * Simplified Docker compose command execution by centralizing configuration selection and argument building.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ls1intum/artemis-ansible-collection/pull/207?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->