### PR TITLE
Migrate ldap, athena, apollon to module-feature flags + drop atlas/aeolus dead config

### DIFF
--- a/roles/artemis/defaults/main.yml
+++ b/roles/artemis/defaults/main.yml
@@ -363,24 +363,23 @@ artemis_internal_ip_allowlist: []
 artemis_computed_is_core_node: "{{ not (continuous_integration.localci is defined and continuous_integration.localci is not none) or (continuous_integration.localci.is_core_node
   is defined and continuous_integration.localci.is_core_node) }}"
 
-# Compute Spring Profiles from set variables
+# Compute Spring Profiles from set variables.
+# LDAP, Athena, Apollon, and Atlas have moved from Spring profiles to module-feature
+# YAML flags (artemis.user-management.ldap.enabled, artemis.athena.enabled,
+# artemis.apollon.enabled, artemis.atlas.enabled) and are no longer injected here.
 artemis_spring_profile_env: "prod"
-artemis_spring_profile_ldap: "{% if ldap.password is defined and ldap.password is not none %},ldap{% endif %}"
 artemis_spring_profile_version_control: "{% if version_control.localvc is defined and version_control.localvc is not none %},localvc{% endif
   %}"
 artemis_spring_profile_continuous_integration: "{% if continuous_integration.jenkins
   is defined and continuous_integration.jenkins is not none %},jenkins{% elif continuous_integration.localci is defined and continuous_integration.localci is not
   none %},localci{% elif continuous_integration.gitlabci is defined and continuous_integration.gitlabci is not none %},gitlabci{% endif %}"
-artemis_spring_profile_athena: "{% if athena is defined and athena is not none %},athena{% endif %}"
-artemis_spring_profile_apollon: "{% if apollon_url is defined and apollon_url is not none %},apollon{% endif %}"
 artemis_spring_profile_scheduling: "{% if node_id is defined and node_id == 1 %},scheduling{% endif %}"
 artemis_spring_profile_docker: "{% if use_docker %},docker{% endif %}"
 artemis_spring_profile_aeolus: "{% if aeolus is defined and aeolus is not none %},aeolus{% endif %}"
-artemis_spring_profile_atlas: "{% if atlas is defined and atlas is not none %},atlas{% endif %}"
 
-artemis_spring_profile_core: "{% if artemis_computed_is_core_node %},core{{ artemis_spring_profile_ldap }}{{ artemis_spring_profile_version_control
-  }}{{ artemis_spring_profile_continuous_integration }}{{ artemis_spring_profile_athena }}{{ artemis_spring_profile_apollon }}{{ artemis_spring_profile_scheduling }}{{ artemis_spring_profile_docker
-  }}{{ artemis_spring_profile_aeolus }}{{ artemis_spring_profile_atlas }}{% endif %}"
+artemis_spring_profile_core: "{% if artemis_computed_is_core_node %},core{{ artemis_spring_profile_version_control
+  }}{{ artemis_spring_profile_continuous_integration }}{{ artemis_spring_profile_scheduling }}{{ artemis_spring_profile_docker
+  }}{{ artemis_spring_profile_aeolus }}{% endif %}"
 artemis_spring_profile_buildagent: "{% if continuous_integration.localci is defined and continuous_integration.localci is not none %}{% if continuous_integration.localci.is_build_agent
   is defined and continuous_integration.localci.is_build_agent is not none and continuous_integration.localci.is_build_agent %},buildagent{% endif %}{% endif %}"
 

--- a/roles/artemis/defaults/main.yml
+++ b/roles/artemis/defaults/main.yml
@@ -281,13 +281,6 @@ artemis_local_llm_deployment_enabled: false
 #     temperature: 0.3
 
 ##############################################################################
-# Aeolus Configuration
-##############################################################################
-#aeolus:
-#  url:
-#  token:
-
-##############################################################################
 # Atlas Configuration
 ##############################################################################
 #atlas:
@@ -375,11 +368,10 @@ artemis_spring_profile_continuous_integration: "{% if continuous_integration.jen
   none %},localci{% elif continuous_integration.gitlabci is defined and continuous_integration.gitlabci is not none %},gitlabci{% endif %}"
 artemis_spring_profile_scheduling: "{% if node_id is defined and node_id == 1 %},scheduling{% endif %}"
 artemis_spring_profile_docker: "{% if use_docker %},docker{% endif %}"
-artemis_spring_profile_aeolus: "{% if aeolus is defined and aeolus is not none %},aeolus{% endif %}"
 
 artemis_spring_profile_core: "{% if artemis_computed_is_core_node %},core{{ artemis_spring_profile_version_control
   }}{{ artemis_spring_profile_continuous_integration }}{{ artemis_spring_profile_scheduling }}{{ artemis_spring_profile_docker
-  }}{{ artemis_spring_profile_aeolus }}{% endif %}"
+  }}{% endif %}"
 artemis_spring_profile_buildagent: "{% if continuous_integration.localci is defined and continuous_integration.localci is not none %}{% if continuous_integration.localci.is_build_agent
   is defined and continuous_integration.localci.is_build_agent is not none and continuous_integration.localci.is_build_agent %},buildagent{% endif %}{% endif %}"
 

--- a/roles/artemis/templates/application-prod.yml.j2
+++ b/roles/artemis/templates/application-prod.yml.j2
@@ -156,6 +156,7 @@ artemis:
 {% endif %}
 {% if ldap.url is defined and ldap.user_dn is defined and ldap.base is defined and ldap.password is defined %}
     ldap:
+      enabled: true
       url: {{ ldap.url }}
       user-dn: {{ ldap.user_dn }}
       base: {{ ldap.base }}
@@ -278,6 +279,7 @@ artemis:
 
 {% if athena is defined %}
   athena:
+    enabled: true
     url: {{ athena.url }}
     secret: {{ athena.secret }}
     restricted-modules: {{ athena.restricted_modules }}
@@ -297,6 +299,7 @@ artemis:
 
 {% if apollon_url is defined %}
   apollon:
+    enabled: true
     conversion-service-url: {{ apollon_url }}
 {% endif %}
   scheduling:

--- a/roles/artemis/templates/application-prod.yml.j2
+++ b/roles/artemis/templates/application-prod.yml.j2
@@ -414,14 +414,6 @@ artemis:
 {% endif %}
 {% endif %}
 
-{% if aeolus.url is defined and aeolus.url is not none %}
-aeolus:
-  url: {{ aeolus.url }}
-{% if aeolus.token is defined and aeolus.token is not none %}
-  token: {{ aeolus.token }}
-{% endif %}
-{% endif %}
-
 jhipster:
 
 {% if artemis_jhipster_jwt is not none %}

--- a/roles/artemis/templates/artemis.env.j2
+++ b/roles/artemis/templates/artemis.env.j2
@@ -74,6 +74,7 @@ ARTEMIS_USERMANAGEMENT_PASSWORDRESET_LINKS_EN='{{ artemis_external_password_rese
 ARTEMIS_USERMANAGEMENT_PASSWORDRESET_LINKS_DE='{{ artemis_external_password_reset_link_de }}'
 {% endif %}
 {% if ldap.url is defined and ldap.user_dn is defined and ldap.base is defined and ldap.password is defined %}
+ARTEMIS_USERMANAGEMENT_LDAP_ENABLED='true'
 ARTEMIS_USERMANAGEMENT_LDAP_URL='{{ ldap.url }}'
 ARTEMIS_USERMANAGEMENT_LDAP_USERDN='{{ ldap.user_dn }}'
 ARTEMIS_USERMANAGEMENT_LDAP_BASE='{{ ldap.base }}'
@@ -185,6 +186,7 @@ ARTEMIS_LTI_OAUTHSECRET='{{ lti.oauth_secret }}'
 ARTEMIS_GIT_NAME='artemis'
 ARTEMIS_GIT_EMAIL='{{ artemis_email }}'
 {% if athena is defined %}
+ARTEMIS_ATHENA_ENABLED='true'
 ARTEMIS_ATHENA_URL='{{ athena.url }}'
 ARTEMIS_ATHENA_SECRET='{{ athena.secret }}'
 {% endif %}
@@ -197,6 +199,7 @@ ARTEMIS_ATLAS_ATLASML_AUTHTOKEN='{{ atlas.atlasml.auth_token }}'
 {% endif %}
 {% endif %}
 {% if apollon_url is defined %}
+ARTEMIS_APOLLON_ENABLED='true'
 ARTEMIS_APOLLON_CONVERSIONSERVICEURL='{{ apollon_url }}'
 {% endif %}
 {% if spring_ai is defined and spring_ai.azure_openai is defined %}

--- a/roles/artemis/templates/artemis.env.j2
+++ b/roles/artemis/templates/artemis.env.j2
@@ -284,12 +284,6 @@ ARTEMIS_THEIA_IMAGES_{{ programming_language_key | upper | regex_replace ("[^A-Z
 {% endfor %}
 {% endif %}
 {% endif %}
-{% if aeolus.url is defined and aeolus.url is not none %}
-AEOLUS_URL='{{ aeolus.url }}'
-{% if aeolus.token is defined and aeolus.token is not none %}
-AEOLUS_TOKEN='{{ aeolus.token }}'
-{% endif %}
-{% endif %}
 ARTEMIS_SCHEDULING_DATAEXPORTCREATIONTIME='{{ artemis_scheduling_data_export_creation_time }}'
 ARTEMIS_SCHEDULING_PROGRAMMINGEXERCISESCLEANUPTIME='{{ artemis_scheduling_programming_exercises_cleanup_time }}'
 ARTEMIS_SCHEDULING_CONTINUOUSPLAGIARISMCONTROLTRIGGERTIME='{{ artemis_scheduling_continuous_plagiarism_control_trigger_time }}'


### PR DESCRIPTION
## Summary

This PR has two related parts:

1. **Migrate `ldap`, `athena`, `apollon` from Spring profiles to module-feature YAML flags** — required for the upgrade to Artemis [#12711](https://github.com/ls1intum/Artemis/pull/12711).
2. **Adjacent dead-config cleanup**: drop the `atlas` Spring-profile injection (migrated in a prior release) and remove the `aeolus` config entirely (Aeolus was removed from Artemis in [#12536](https://github.com/ls1intum/Artemis/pull/12536)).

### Part 1 — Profile → module-feature migration

| Old (profile)                                    | New (YAML flag)                              |
| ------------------------------------------------ | -------------------------------------------- |
| `--spring.profiles.active=…,ldap`                | `artemis.user-management.ldap.enabled: true` |
| `--spring.profiles.active=…,athena`              | `artemis.athena.enabled: true`               |
| `--spring.profiles.active=…,apollon`             | `artemis.apollon.enabled: true`              |
| `--spring.profiles.active=…,saml2`               | `artemis.user-management.saml2.enabled: true` (no ansible-managed env uses this today) |

Both new checks use `getPropertyOrExitArtemis(...)`. Once #12711 is released, **a node that activated the profile but did not set the flag will fail to start.** This PR updates the collection so the rendered `application-prod.yml` carries the new flags and the rendered systemd unit / Docker env no longer lists the (now removed) profile names.

### Part 2 — Dead-config cleanup

- **Atlas**: the `atlas` Spring profile was retired in an earlier Artemis release in favor of `artemis.atlas.enabled`. The collection still injected `,atlas` into `--spring.profiles.active` — harmless but dead.
- **Aeolus**: Aeolus was removed from Artemis entirely in ls1intum/Artemis#12536. The collection still rendered an `aeolus:` block in `application-prod.yml`, exported `AEOLUS_URL` / `AEOLUS_TOKEN` in the Docker env file, and injected `,aeolus` into `--spring.profiles.active` — all unused.

## Changes

**`roles/artemis/templates/application-prod.yml.j2`**
- Add `enabled: true` inside the existing `ldap`, `athena`, and `apollon` blocks. Rendered under the same gate as before (whenever the inventory defines `ldap.url`, `athena`, or `apollon_url`), so no new inventory variables are introduced and the previous semantics ("config present ⇒ feature on") are preserved exactly.
- Remove the unused `aeolus:` block.

**`roles/artemis/templates/artemis.env.j2`** (Docker deployments)
- Emit `ARTEMIS_USERMANAGEMENT_LDAP_ENABLED='true'`, `ARTEMIS_ATHENA_ENABLED='true'`, `ARTEMIS_APOLLON_ENABLED='true'` under the same conditions as the existing URL/secret env vars. Docker installs source config from this file rather than from the rendered YAML, so without these the four features would silently break in Docker.
- Remove the unused `AEOLUS_URL` / `AEOLUS_TOKEN` env vars.

**`roles/artemis/defaults/main.yml`**
- Drop the obsolete `artemis_spring_profile_{ldap,athena,apollon,atlas,aeolus}` injections from `artemis_spring_profile_core`. The systemd unit / Docker env no longer append dead profile names to `--spring.profiles.active`.
- Remove the commented-out `aeolus:` placeholder block and its section header.

## Out of scope (follow-ups)

- **SAML2** in this collection: no inventory in `ls1intum/artemis-ansible` configures SAML2 today. Artemis #12711 ships `application-saml2.yml.example` as the operator-facing template; the collection can be extended once an environment needs it.
- **`group_vars/artemistests_aeolus.yml` in `ls1intum/artemis-ansible`**: orphan file (no longer referenced by any group in `hosts`). Should be deleted in a small follow-up PR against the inventory repo.
- **Version bump**: deliberately omitted to avoid conflict with the in-flight `feat/maven-cache` branch which already stages a bump. Bump in a follow-up after both land.

## Affected environments (via `ls1intum/artemis-ansible`)

After this collection is updated and the consumer playbook is re-run, the rendered `/opt/artemis/application-prod.yml` on the following envs will gain the new `enabled: true` flags, and the rendered `/etc/systemd/system/artemis.service` will drop the obsolete profile names (`ldap`, `athena`, `apollon`, `atlas`, `aeolus`):

| Environment            | gets `athena.enabled` | gets `apollon.enabled` | gets `ldap.enabled` |
| ---------------------- | :-------------------: | :--------------------: | :-----------------: |
| `artemis_production`   | ✓                     | ✓ (via prod_like_common) | ✓ (via prod_like_common) |
| `artemis_staging1`     | ✓                     | ✓                      | ✓                   |
| `artemis_staging2`     | ✓                     | ✓                      | ✓                   |
| `artemis_staging_localci` | ✓                  | ✓                      | ✓                   |
| `artemistest1..10` + migration | —             | ✓ (via tests_common_config) | ✓ (in `artemistests_ldap` group: 1,2,3,4,5,6,8,9,10,migration) |

Apollon, like LDAP, is currently active everywhere through `artemis_prod_like_common` / `artemistests_common_config` even on envs where it is not exercised (because no separate test group selects it). This PR does not change that — it only renames the activation mechanism.

## Rollout plan

1. **Merge this PR** (collection) and tag a release.
2. **Bump the `ls1intum.artemis` collection pin** in `ls1intum/artemis-ansible` requirements to the new tag.
3. **Roll out to test envs first** (`artemistest*`) to confirm the new YAML is well-formed and `/management/info → activeModuleFeatures` lists `athena` / `apollon` / `ldap` as expected.
4. **Then `artemis_staging_localci` → `artemis_staging2` → `artemis_staging1`**, finally `artemis_production`.
5. Each rollout must be paired with an Artemis release that includes ls1intum/Artemis#12711. Earlier Artemis releases do not know the new YAML flags (they are silently ignored, but the removed profiles also won't activate the features), so the collection update is safe to roll out **after** the Artemis release; rolling it out **before** the Artemis release would silently disable the four features until Artemis is upgraded.

## Test plan

- [ ] `ansible-lint` clean on the changed files
- [ ] Render the template against a representative inventory (e.g. `artemis_staging1_core`) and diff against the current `/opt/artemis/application-prod.yml` on `staging1node1` — expect three additions (`enabled: true` under `athena`, `apollon`, `ldap`) and one deletion (the `aeolus:` block, which `staging1node1` doesn't have configured anyway)
- [ ] Render the systemd unit and diff against the current `/etc/systemd/system/artemis.service` on `staging1node1` — expect `ldap,athena,apollon,atlas` to disappear from `--spring.profiles.active` (`aeolus` was never in staging1's profile list)
- [ ] Render the Docker env file and confirm `ARTEMIS_*_ENABLED='true'` env vars appear for the three migrated features and `AEOLUS_*` env vars are gone
- [ ] Smoke-test on `staging1` after deploy: `GET /management/info` returns `activeModuleFeatures` containing `athena`, `apollon`, `ldap` (no `saml2` on staging1); admin → Feature Toggles UI lists them under "Module Features"

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated optional module configuration. LDAP, Athena, Apollon, and Atlas modules are no longer automatically included in the core profile and must now be explicitly enabled in your configuration when required.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ls1intum/artemis-ansible-collection/pull/208?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
