### PR TITLE
Migrate Spring AI config from Azure module to unified OpenAI tree (Spring AI M6)

### DIFF
--- a/roles/artemis/README.md
+++ b/roles/artemis/README.md
@@ -122,16 +122,24 @@ spring_ai:
 
 artemis_hyperion_enabled: true
 ```
-Rendered into application-prod.yml under `spring_ai` (if spring_ai.azure_openai is present) and general Artemis section:
+Rendered into application-prod.yml under `spring_ai` and exported in `artemis.env` only if `spring_ai.azure_openai` is fully configured with non-empty `api_key`, `endpoint`, and `deployment_name`:
 
 ```text
-spring.ai.azure.openai.api-key
-spring.ai.azure.openai.endpoint
-spring.ai.azure.openai.chat.options.deployment-name
-spring.ai.azure.openai.chat.options.temperature
+spring.ai.model.chat                # 'openai'
+spring.ai.openai.api-key
+spring.ai.openai.base-url           # rendered from spring_ai.azure_openai.endpoint
+spring.ai.openai.microsoft-foundry  # true
+spring.ai.openai.timeout            # default 5m
+spring.ai.openai.chat.model         # rendered from spring_ai.azure_openai.deployment_name
+spring.ai.openai.chat.temperature
 
 artemis.hyperion.enabled
 ```
+
+> Since Spring AI 2.0.0-M6, Azure OpenAI / Microsoft Foundry is served through the unified
+> `spring.ai.openai.*` tree (the former `spring.ai.azure.openai.*` keys and the azure-openai starter
+> module were removed upstream). The inventory variable names under `spring_ai.azure_openai` are
+> unchanged for backward compatibility.
 
 Iris configuration:
 ```

--- a/roles/artemis/README.md
+++ b/roles/artemis/README.md
@@ -128,7 +128,7 @@ Rendered into application-prod.yml under `spring_ai` and exported in `artemis.en
 spring.ai.model.chat = openai
 spring.ai.openai.api-key
 spring.ai.openai.base-url            # from spring_ai.azure_openai.endpoint
-spring.ai.openai.microsoft-foundry   # default true; set false for plain OpenAI-compatible endpoints
+spring.ai.openai.microsoft-foundry   # default true
 spring.ai.openai.timeout             # default 5m
 spring.ai.openai.chat.model          # from spring_ai.azure_openai.deployment_name
 spring.ai.openai.chat.temperature

--- a/roles/artemis/README.md
+++ b/roles/artemis/README.md
@@ -125,21 +125,18 @@ artemis_hyperion_enabled: true
 Rendered into application-prod.yml under `spring_ai` and exported in `artemis.env` only if `spring_ai.azure_openai` is fully configured with non-empty `api_key`, `endpoint`, and `deployment_name`:
 
 ```text
-spring.ai.model.chat                # 'openai'
+spring.ai.model.chat = openai
 spring.ai.openai.api-key
-spring.ai.openai.base-url           # rendered from spring_ai.azure_openai.endpoint
-spring.ai.openai.microsoft-foundry  # true
-spring.ai.openai.timeout            # default 5m
-spring.ai.openai.chat.model         # rendered from spring_ai.azure_openai.deployment_name
+spring.ai.openai.base-url            # from spring_ai.azure_openai.endpoint
+spring.ai.openai.microsoft-foundry   # default true; set false for plain OpenAI-compatible endpoints
+spring.ai.openai.timeout             # default 5m
+spring.ai.openai.chat.model          # from spring_ai.azure_openai.deployment_name
 spring.ai.openai.chat.temperature
 
 artemis.hyperion.enabled
 ```
 
-> Since Spring AI 2.0.0-M6, Azure OpenAI / Microsoft Foundry is served through the unified
-> `spring.ai.openai.*` tree (the former `spring.ai.azure.openai.*` keys and the azure-openai starter
-> module were removed upstream). The inventory variable names under `spring_ai.azure_openai` are
-> unchanged for backward compatibility.
+> The `spring_ai.azure_openai.*` inventory variables render the unified `spring.ai.openai.*` properties; the variable namespace is kept for backward compatibility.
 
 Iris configuration:
 ```

--- a/roles/artemis/templates/application-prod.yml.j2
+++ b/roles/artemis/templates/application-prod.yml.j2
@@ -48,23 +48,20 @@ spring:
 {% if artemis_computed_is_core_node %}
 
 {% if spring_ai is defined and spring_ai.azure_openai is defined
-      and spring_ai.azure_openai.api_key is defined and spring_ai.azure_openai.api_key is not none and spring_ai.azure_openai.api_key | length > 0
-      and spring_ai.azure_openai.endpoint is defined and spring_ai.azure_openai.endpoint is not none and spring_ai.azure_openai.endpoint | length > 0
-      and spring_ai.azure_openai.deployment_name is defined and spring_ai.azure_openai.deployment_name is not none and spring_ai.azure_openai.deployment_name | length > 0 %}
+      and spring_ai.azure_openai.api_key | default('') | length > 0
+      and spring_ai.azure_openai.endpoint | default('') | length > 0
+      and spring_ai.azure_openai.deployment_name | default('') | length > 0 %}
   ai:
     model:
       chat: openai
-    # Single OpenAI module (official OpenAI Java SDK) since Spring AI 2.0.0-M6: one config tree serves
-    # Azure OpenAI / Microsoft Foundry, OpenAI itself, and OpenAI-compatible servers. The former
-    # spring.ai.azure.openai tree and the azure-openai starter module were removed upstream.
     openai:
       api-key: {{ spring_ai.azure_openai.api_key | quote }}
       base-url: {{ spring_ai.azure_openai.endpoint | quote }}
-      microsoft-foundry: true # auto-detected for *.openai.azure.com base URLs; set explicitly for custom domains
-      # HTTP client request timeout (default 60s) — LLM tool-calling loops can need several minutes.
+      # true routes auth as an Azure api-key header; set false for plain OpenAI-compatible endpoints.
+      microsoft-foundry: {{ spring_ai.azure_openai.microsoft_foundry | default(true) | lower }}
+      # Connection-level timeout feeds the HTTP client; tool-calling loops exceed the 60s default.
       timeout: {{ spring_ai.azure_openai.timeout | default('5m') }}
       chat:
-        # The Azure deployment name; used as the request model by the default ChatClient.
         model: {{ spring_ai.azure_openai.deployment_name | quote }}
         temperature: {{ spring_ai.azure_openai.temperature | default(1.0) }}
 {% endif %}

--- a/roles/artemis/templates/application-prod.yml.j2
+++ b/roles/artemis/templates/application-prod.yml.j2
@@ -59,7 +59,7 @@ spring:
       base-url: {{ spring_ai.azure_openai.endpoint | quote }}
       # true routes auth as an Azure api-key header; set false for plain OpenAI-compatible endpoints.
       microsoft-foundry: {{ spring_ai.azure_openai.microsoft_foundry | default(true) | lower }}
-      # Connection-level timeout feeds the HTTP client; tool-calling loops exceed the 60s default.
+      # tool-calling loops can exceed the 60s default
       timeout: {{ spring_ai.azure_openai.timeout | default('5m') }}
       chat:
         model: {{ spring_ai.azure_openai.deployment_name | quote }}

--- a/roles/artemis/templates/application-prod.yml.j2
+++ b/roles/artemis/templates/application-prod.yml.j2
@@ -47,18 +47,26 @@ spring:
 {% endif %}
 {% if artemis_computed_is_core_node %}
 
-{% if spring_ai is defined and spring_ai.azure_openai is defined %}
+{% if spring_ai is defined and spring_ai.azure_openai is defined
+      and spring_ai.azure_openai.api_key is defined and spring_ai.azure_openai.api_key is not none and spring_ai.azure_openai.api_key | length > 0
+      and spring_ai.azure_openai.endpoint is defined and spring_ai.azure_openai.endpoint is not none and spring_ai.azure_openai.endpoint | length > 0
+      and spring_ai.azure_openai.deployment_name is defined and spring_ai.azure_openai.deployment_name is not none and spring_ai.azure_openai.deployment_name | length > 0 %}
   ai:
     model:
-      chat: azure-openai
-    azure:
-      openai:
-        api-key: {{ spring_ai.azure_openai.api_key | quote }}
-        endpoint: {{ spring_ai.azure_openai.endpoint | quote }}
-        chat:
-          options:
-            deployment-name: {{ spring_ai.azure_openai.deployment_name | quote }}
-            temperature: {{ spring_ai.azure_openai.temperature | default(1.0) }}
+      chat: openai
+    # Single OpenAI module (official OpenAI Java SDK) since Spring AI 2.0.0-M6: one config tree serves
+    # Azure OpenAI / Microsoft Foundry, OpenAI itself, and OpenAI-compatible servers. The former
+    # spring.ai.azure.openai tree and the azure-openai starter module were removed upstream.
+    openai:
+      api-key: {{ spring_ai.azure_openai.api_key | quote }}
+      base-url: {{ spring_ai.azure_openai.endpoint | quote }}
+      microsoft-foundry: true # auto-detected for *.openai.azure.com base URLs; set explicitly for custom domains
+      # HTTP client request timeout (default 60s) — LLM tool-calling loops can need several minutes.
+      timeout: {{ spring_ai.azure_openai.timeout | default('5m') }}
+      chat:
+        # The Azure deployment name; used as the request model by the default ChatClient.
+        model: {{ spring_ai.azure_openai.deployment_name | quote }}
+        temperature: {{ spring_ai.azure_openai.temperature | default(1.0) }}
 {% endif %}
 
 {% if shared_monitoring_host_v4 is not none %}

--- a/roles/artemis/templates/artemis.env.j2
+++ b/roles/artemis/templates/artemis.env.j2
@@ -202,12 +202,19 @@ ARTEMIS_ATLAS_ATLASML_AUTHTOKEN='{{ atlas.atlasml.auth_token }}'
 ARTEMIS_APOLLON_ENABLED='true'
 ARTEMIS_APOLLON_CONVERSIONSERVICEURL='{{ apollon_url }}'
 {% endif %}
-{% if spring_ai is defined and spring_ai.azure_openai is defined %}
-SPRING_AI_MODEL_CHAT='azure-openai'
-SPRING_AI_AZURE_OPENAI_API_KEY='{{ spring_ai.azure_openai.api_key }}'
-SPRING_AI_AZURE_OPENAI_ENDPOINT='{{ spring_ai.azure_openai.endpoint }}'
-SPRING_AI_AZURE_OPENAI_CHAT_OPTIONS_DEPLOYMENT_NAME='{{ spring_ai.azure_openai.deployment_name }}'
-SPRING_AI_AZURE_OPENAI_CHAT_OPTIONS_TEMPERATURE='{{ spring_ai.azure_openai.temperature | default(1.0) }}'
+{% if spring_ai is defined and spring_ai.azure_openai is defined
+	and spring_ai.azure_openai.api_key is defined and spring_ai.azure_openai.api_key is not none and spring_ai.azure_openai.api_key | length > 0
+	and spring_ai.azure_openai.endpoint is defined and spring_ai.azure_openai.endpoint is not none and spring_ai.azure_openai.endpoint | length > 0
+	and spring_ai.azure_openai.deployment_name is defined and spring_ai.azure_openai.deployment_name is not none and spring_ai.azure_openai.deployment_name | length > 0 %}
+{# Spring AI 2.0.0-M6 unified OpenAI module: Azure OpenAI / Microsoft Foundry is served via the #}
+{# spring.ai.openai.* tree. The former spring.ai.azure.openai.* keys were removed upstream. #}
+SPRING_AI_MODEL_CHAT='openai'
+SPRING_AI_OPENAI_API_KEY='{{ spring_ai.azure_openai.api_key }}'
+SPRING_AI_OPENAI_BASE_URL='{{ spring_ai.azure_openai.endpoint }}'
+SPRING_AI_OPENAI_MICROSOFT_FOUNDRY='true'
+SPRING_AI_OPENAI_TIMEOUT='{{ spring_ai.azure_openai.timeout | default("5m") }}'
+SPRING_AI_OPENAI_CHAT_MODEL='{{ spring_ai.azure_openai.deployment_name }}'
+SPRING_AI_OPENAI_CHAT_TEMPERATURE='{{ spring_ai.azure_openai.temperature | default(1.0) }}'
 {% endif %}
 {% if iris is defined and iris is not none %}
 ARTEMIS_IRIS_ENABLED='true'

--- a/roles/artemis/templates/artemis.env.j2
+++ b/roles/artemis/templates/artemis.env.j2
@@ -203,16 +203,14 @@ ARTEMIS_APOLLON_ENABLED='true'
 ARTEMIS_APOLLON_CONVERSIONSERVICEURL='{{ apollon_url }}'
 {% endif %}
 {% if spring_ai is defined and spring_ai.azure_openai is defined
-	and spring_ai.azure_openai.api_key is defined and spring_ai.azure_openai.api_key is not none and spring_ai.azure_openai.api_key | length > 0
-	and spring_ai.azure_openai.endpoint is defined and spring_ai.azure_openai.endpoint is not none and spring_ai.azure_openai.endpoint | length > 0
-	and spring_ai.azure_openai.deployment_name is defined and spring_ai.azure_openai.deployment_name is not none and spring_ai.azure_openai.deployment_name | length > 0 %}
-{# Spring AI 2.0.0-M6 unified OpenAI module: Azure OpenAI / Microsoft Foundry is served via the #}
-{# spring.ai.openai.* tree. The former spring.ai.azure.openai.* keys were removed upstream. #}
+      and spring_ai.azure_openai.api_key | default('') | length > 0
+      and spring_ai.azure_openai.endpoint | default('') | length > 0
+      and spring_ai.azure_openai.deployment_name | default('') | length > 0 %}
 SPRING_AI_MODEL_CHAT='openai'
 SPRING_AI_OPENAI_API_KEY='{{ spring_ai.azure_openai.api_key }}'
 SPRING_AI_OPENAI_BASE_URL='{{ spring_ai.azure_openai.endpoint }}'
-SPRING_AI_OPENAI_MICROSOFT_FOUNDRY='true'
-SPRING_AI_OPENAI_TIMEOUT='{{ spring_ai.azure_openai.timeout | default("5m") }}'
+SPRING_AI_OPENAI_MICROSOFT_FOUNDRY='{{ spring_ai.azure_openai.microsoft_foundry | default(true) | lower }}'
+SPRING_AI_OPENAI_TIMEOUT='{{ spring_ai.azure_openai.timeout | default('5m') }}'
 SPRING_AI_OPENAI_CHAT_MODEL='{{ spring_ai.azure_openai.deployment_name }}'
 SPRING_AI_OPENAI_CHAT_TEMPERATURE='{{ spring_ai.azure_openai.temperature | default(1.0) }}'
 {% endif %}


### PR DESCRIPTION
## ⚠️ Blocked on ls1intum/Artemis#12895 — do not merge / deploy before that ships

This is a **draft** because it must land in lockstep with the Artemis Spring AI 2.0.0-M6/RC2 upgrade ([ls1intum/Artemis#12895](https://github.com/ls1intum/Artemis/pull/12895), still open; `develop` is on M4). Deploying these templates against a current (Azure-format) Artemis release would break Hyperion/Atlas startup.

## Problem

Spring AI 2.0.0-M6 removes the `spring-ai-starter-model-azure-openai` module and the entire `spring.ai.azure.openai.*` property tree. Azure OpenAI / Microsoft Foundry is now served through the **single OpenAI module** (`spring.ai.openai.*`, backed by the official OpenAI Java SDK). The Artemis prod templates here still render the removed Azure keys.

## Solution

`roles/artemis/templates/application-prod.yml.j2` and `artemis.env.j2`:

| Old (removed in M6) | New |
|---|---|
| `spring.ai.model.chat: azure-openai` | `spring.ai.model.chat: openai` |
| `spring.ai.azure.openai.endpoint` | `spring.ai.openai.base-url` |
| `spring.ai.azure.openai.api-key` | `spring.ai.openai.api-key` |
| `spring.ai.azure.openai.chat.options.deployment-name` | `spring.ai.openai.chat.model` |
| `spring.ai.azure.openai.chat.options.temperature` | `spring.ai.openai.chat.temperature` |
| — | `spring.ai.openai.microsoft-foundry: true` (new) |
| — | `spring.ai.openai.timeout: 5m` (new, for tool-calling loops) |

Verified against the M6 autoconfigure classes: `OpenAiChatAutoConfiguration` builds the model from `OpenAiChatProperties.toOptions()`, which reads the **top-level** `chat.model` / `chat.temperature` — the nested `chat.options.*` sub-tree is **not** consumed, and `chat.completions-path` was removed. `microsoft-foundry` is auto-detected for `*.openai.azure.com` but is set explicitly here for robustness against custom domains/gateways.

Also:
- The whole block now renders **only** when `api_key`, `endpoint`, and `deployment_name` are all defined and non-empty (previously rendered an incomplete block if partially configured).
- README updated to the new rendered keys.

## Backward compatibility

Inventory variable names (`spring_ai.azure_openai.*`) are **unchanged** — only the rendered Spring keys change, so existing host_vars/vault entries need no edits.

## Testing

- Rendered both templates with Jinja2 for the fully-configured case → output YAML parses; env vars correct.
- Verified the presence-guards omit the block when `api_key` is empty or `deployment_name`/`endpoint` is missing.

## Notes
- Atlas model config (`atlas.chat-model` / `atlas.orchestrator.model`) is not exposed via this role; prod relies on the Artemis defaults (`gpt-5.4-mini` / `gpt-5.4`), which are sent as Azure deployment names per-request. Confirm those deployments exist in the target Azure resource.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Review & validation

Reviewed by a multi-agent pass (websearch-grounded rubric, two rounds, deliberately stricter each round). Every correctness claim was checked against the **pinned `spring-ai 2.0.0-RC2` artifact** (decompiled `OpenAiCommonProperties`, `OpenAiChatProperties`, `OpenAiSetup`, and Spring Boot 4 `SystemEnvironmentPropertyMapper`) — public release docs disagree with the pinned build and are not authoritative here.

### Rubric
| Dimension | Grade | Basis |
|---|---|---|
| Spring AI config correctness | A | All rendered keys are real, bound, and consumed. |
| Env-var binding correctness | A | Underscore forms bind via the relaxed `SYSTEM_ENVIRONMENT` mapping. |
| Ansible/Jinja2 quality | A− | Guard is lean and AttributeError-safe; quoting matches repo idiom. |
| Leanness / repo integration | A− | Two load-bearing comments remain; migration narration removed. |

### Verified
- `spring.ai.openai.base-url`, `api-key`, `microsoft-foundry`, `timeout`, `chat.model` are all bound `OpenAiCommonProperties`/`OpenAiChatProperties` fields; `chat.model` is consumed via `toOptions()` (`chat.options.*` and `chat.completions-path` are not).
- `microsoft-foundry` selects the auth scheme: `true` → `MICROSOFT_FOUNDRY` provider → Azure `api-key` header; `false` → `OPEN_AI` → `Authorization: Bearer`. It is configurable (default `true`) so non-Azure OpenAI-compatible endpoints work. Hardcoding `true` would 401 against a Bearer-only endpoint.
- Env-var names like `SPRING_AI_OPENAI_MICROSOFT_FOUNDRY` / `SPRING_AI_OPENAI_API_KEY` bind to the hyphenated properties: `SystemEnvironmentPropertyMapper.map` emits both the `SYSTEM_ENVIRONMENT` (dash→`_`) and `LEGACY_SYSTEM_ENVIRONMENT` (dash-removed) candidates. Same mechanism the pre-existing `SPRING_AI_AZURE_OPENAI_CHAT_OPTIONS_DEPLOYMENT_NAME` already relies on.
- Guard `X | default('') | length > 0` is correct when `azure_openai` is undefined, present-but-missing-a-subkey, or a sub-value is empty. Boolean/float coercion holds in both YAML (bare) and env (quoted-string) contexts.
- Templates render and parse as valid YAML; guards omit the block on any missing/empty required field.

### Out of scope (pre-existing repo patterns, not introduced here)
- The same config is rendered to both `application-prod.yml` and `artemis.env`; env wins on precedence. Left as-is to match every other service block.
- `| quote` on YAML scalars is `shlex` quoting, not YAML quoting — would break on a value containing a single quote. Pre-existing repo idiom (e.g. `sentry.dsn | quote`); not changed here to avoid an inconsistent one-off.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Azure OpenAI configuration documentation to reflect unified property structure.

* **Configuration Changes**
  * Azure OpenAI configuration now uses unified OpenAI properties instead of Azure-specific namespaces.
  * Configuration now requires `api_key`, `endpoint`, and `deployment_name` to be fully set before activation.
  * Updated application and environment templates to support new configuration structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->