### PR TITLE
Add LTI configuration variable to trust external LTI systems

### DIFF
--- a/roles/artemis/README.md
+++ b/roles/artemis/README.md
@@ -165,6 +165,8 @@ lti:
   trust_external_lti_systems: true
 ```
 
+**Security note:** While `lti.trust_external_lti_systems` defaults to `false`, it should only be set to `true` if you are sure to trust LTI consumers to use Artemis as an LTI provider and allow users to authenticate to Artemis from within the LTI consumer; otherwise, this might lead to unsafe configurations.
+
 ### Additional Variables for multi node installations
 
 Registry Configuration:

--- a/roles/artemis/README.md
+++ b/roles/artemis/README.md
@@ -162,6 +162,7 @@ LTI configuration:
 ```
 lti:
   oauth_secret: "lti_oauth_secret"
+  trust_external_lti_systems: true
 ```
 
 ### Additional Variables for multi node installations

--- a/roles/artemis/defaults/main.yml
+++ b/roles/artemis/defaults/main.yml
@@ -190,6 +190,7 @@ artemis_passkey_enabled: false
 #
 #lti:
 #  oauth_secret:
+#  trustExternalLTISystems: false
 #
 #mail:
 #  hostname:

--- a/roles/artemis/templates/application-prod.yml.j2
+++ b/roles/artemis/templates/application-prod.yml.j2
@@ -275,7 +275,7 @@ artemis:
     id: artemis_lti
     oauth-key: artemis_lti_key
     oauth-secret: {{ lti.oauth_secret }}
-    trustExternalLTISystems: {{ lti.trust_external_lti_systems | default(false) | to_json }}
+    trustExternalLTISystems: {{ lti.trust_external_lti_systems | default(false) | lower }}
 {% endif %}
 
 {% if athena is defined %}

--- a/roles/artemis/templates/application-prod.yml.j2
+++ b/roles/artemis/templates/application-prod.yml.j2
@@ -275,6 +275,7 @@ artemis:
     id: artemis_lti
     oauth-key: artemis_lti_key
     oauth-secret: {{ lti.oauth_secret }}
+    trustExternalLTISystems: {{ lti.trust_external_lti_systems | default(false) | to_json }}
 {% endif %}
 
 {% if athena is defined %}

--- a/roles/artemis/templates/artemis.env.j2
+++ b/roles/artemis/templates/artemis.env.j2
@@ -182,7 +182,7 @@ ARTEMIS_LTI_ENABLED='true'
 ARTEMIS_LTI_ID='artemis_lti'
 ARTEMIS_LTI_OAUTHKEY='artemis_lti_key'
 ARTEMIS_LTI_OAUTHSECRET='{{ lti.oauth_secret }}'
-ARTEMIS_LTI_TRUSTEXTERNALLTISYSTEMS='{{ lti.trust_external_lti_systems | default(false) | to_json }}'
+ARTEMIS_LTI_TRUSTEXTERNALLTISYSTEMS='{{ lti.trust_external_lti_systems | default(false) | lower }}'
 {% endif %}
 ARTEMIS_GIT_NAME='artemis'
 ARTEMIS_GIT_EMAIL='{{ artemis_email }}'

--- a/roles/artemis/templates/artemis.env.j2
+++ b/roles/artemis/templates/artemis.env.j2
@@ -182,6 +182,7 @@ ARTEMIS_LTI_ENABLED='true'
 ARTEMIS_LTI_ID='artemis_lti'
 ARTEMIS_LTI_OAUTHKEY='artemis_lti_key'
 ARTEMIS_LTI_OAUTHSECRET='{{ lti.oauth_secret }}'
+ARTEMIS_LTI_TRUSTEXTERNALLTISYSTEMS='{{ lti.trust_external_lti_systems | default(false) | to_json }}'
 {% endif %}
 ARTEMIS_GIT_NAME='artemis'
 ARTEMIS_GIT_EMAIL='{{ artemis_email }}'


### PR DESCRIPTION
### Summary

External LTI systems need to be trusted in order to let the users authenticate to Artemis as an LTI provider from an LTI comsumer like Open edX.
The variable defaults to not trust external LTI systems.

### Motivation

In the LMS Open edX  and other LTI consumers who like to use Artemis as an LTI provider to make use of Artemis' learning environment the authentication fails for users who want to authenticate to Artemis within Open edX.
This behaviour can be altered by providing a configuration variable `trustExternalLTISystems`, so that external LTI systems are trusted.
This Ansible Collection misses the respective configuration variable that this PR implements.

### Testing

Due to the default value of not trusting external LTI system which is equal to the default value of Artemis this change should not affect any setups that do not yet configure this configuration variable in the LTI settings.

Closes #210 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new configuration option to control whether external LTI systems are trusted, with a default of `false` for improved safety.

* **Documentation**
  * Updated the Artemis role documentation to include the new external LTI trust setting in the configuration example and added a security note explaining when to enable it.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->