### PR TITLE
Add variable for notification email address without email subaddressing

### DIFF
--- a/roles/artemis/README.md
+++ b/roles/artemis/README.md
@@ -173,6 +173,8 @@ mail:
   ssl_trust: "smtp.example.com"
 ```
 
+- `artemis_notification_email` overrides the sender address of notification emails. Defaults to `<local-part>+notification@<domain>` derived from `artemis_email` (subaddressing); set it explicitly if your mail server does not support subaddressing.
+
 LTI configuration:
 ```
 lti:

--- a/roles/artemis/defaults/main.yml
+++ b/roles/artemis/defaults/main.yml
@@ -53,6 +53,7 @@ artemis_email: artemis.in@tum.de
 artemis_operator_name: "Anonymous University"
 artemis_operator_admin_name: "Anonymous University Admin"
 artemis_notification_from: "Artemis Notification"
+# artemis_notification_email: noreply@example.com  # defaults to <local-part>+notification@<domain> derived from artemis_email
 
 artemis_telemetry_enabled: true
 artemis_send_admin_details: true

--- a/roles/artemis/templates/application-prod.yml.j2
+++ b/roles/artemis/templates/application-prod.yml.j2
@@ -437,7 +437,7 @@ jhipster:
 
   mail:
     base-url: {{ artemis_server_url }}
-    from: '{{artemis_notification_from}} <{{ artemis_email.split("@")[0] }}+notification@{{ artemis_email.split("@")[1] }}>'
+    from: '{{artemis_notification_from}} <{{ artemis_notification_email | default([artemis_email.split("@")[0], "+notification@", artemis_email.split("@")[1]]|join()) }}>'
 
 {% if sentry.dsn | default('') | length %}
 sentry:

--- a/roles/artemis/templates/artemis.env.j2
+++ b/roles/artemis/templates/artemis.env.j2
@@ -301,7 +301,7 @@ JHIPSTER_CORS_ALLOWEDORIGINS='{{ artemis_CORS_allowed_origins }}'
 JHIPSTER_REGISTRY_PASSWORD='{{ artemis_jhipster_registry_password }}'
 {% endif %}
 JHIPSTER_MAIL_BASEURL='{{ artemis_server_url }}'
-JHIPSTER_MAIL_FROM='{{artemis_notification_from}} <{{ artemis_email.split('@')[0] }}+notification@{{ artemis_email.split('@')[1] }}>'
+JHIPSTER_MAIL_FROM='{{artemis_notification_from}} <{{ artemis_notification_email | default([artemis_email.split('@')[0], '+notification@', artemis_email.split('@')[1]]|join()) }}>'
 INFO_OPERATORNAME='{{ artemis_operator_name }}'
 INFO_OPERATORADMINNAME='{{ artemis_operator_admin_name }}'
 INFO_CONTACT='{{ artemis_email }}'


### PR DESCRIPTION
### Summary

For cases in which email subaddressing is not supported by the mail server or other reasons why the default email address is not an option, a notification sender email address can be specified which does not make use of email subaddressing.
The default value of the variable uses email subaddressing according to this pattern: <local-part>+notification@<email-domain>.

### Motivation

There are reason why email subaddressing might not be an option for notification emails.
For these cases a configurable variable is missing, which this PR implements.

### Testing

Due to the default value that is equal to the previously set value this change does not alter the configuration of existing installations.

Closes #211

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Notification email configuration has been updated to support custom sender email addresses. When not specified, the system falls back to automatically generating notification addresses from the primary email.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->