### PR TITLE
Add more variables for mail server configurations

### DIFF
--- a/roles/artemis/README.md
+++ b/roles/artemis/README.md
@@ -171,6 +171,10 @@ mail:
   password: "smtp_password"
   protocol: "smtp"
   ssl_trust: "smtp.example.com"
+  tls: true
+  smtp_auth: true
+  smtp_ssl_enable: false
+  smtp_starttls_enable: true
 ```
 
 LTI configuration:

--- a/roles/artemis/defaults/main.yml
+++ b/roles/artemis/defaults/main.yml
@@ -205,6 +205,10 @@ artemis_passkey_enabled: false
 #  password:
 #  protocol:
 #  ssl_trust:
+#  tls: true
+#  smtp_auth: true
+#  smtp_ssl_enable: false
+#  smtp_starttls_enable: true
 #
 #post_hog:
 #  host:

--- a/roles/artemis/templates/application-prod.yml.j2
+++ b/roles/artemis/templates/application-prod.yml.j2
@@ -81,11 +81,10 @@ spring:
     properties.mail.smtp:
       auth: {{ mail.smtp_auth | default(true) | to_json }}
       ssl:
+        trust: {{ mail.ssl_trust }}
         enable: {{ mail.smtp_ssl_enable | default(false) | to_json }}
       starttls:
         enable: {{ mail.smtp_starttls_enable | default(true) | to_json }}
-      ssl:
-        trust: {{ mail.ssl_trust }}
 {% endif %}
 {% else %}
   liquibase:

--- a/roles/artemis/templates/application-prod.yml.j2
+++ b/roles/artemis/templates/application-prod.yml.j2
@@ -70,14 +70,20 @@ spring:
   mail:
     host: {{ mail.hostname }}
     port: {{ mail.port }}
+    {% if mail.username is defined and mail.username is not none %}
     username: {{ mail.username }}
+    {% endif %}
+    {% if mail.password is defined and mail.password is not none %}
     password: {{ mail.password }}
+    {% endif %}
     protocol: {{ mail.protocol }}
-    tls: true
+    tls: {{ mail.tls | default(true) | to_json }}
     properties.mail.smtp:
-      auth: true
+      auth: {{ mail.smtp_auth | default(true) | to_json }}
+      ssl:
+        enable: {{ mail.smtp_ssl_enable | default(false) | to_json }}
       starttls:
-        enable: true
+        enable: {{ mail.smtp_starttls_enable | default(true) | to_json }}
       ssl:
         trust: {{ mail.ssl_trust }}
 {% endif %}

--- a/roles/artemis/templates/artemis.env.j2
+++ b/roles/artemis/templates/artemis.env.j2
@@ -38,12 +38,17 @@ SPRING_PROMETHEUS_MONITORINGIP='{{ shared_monitoring_host_v4 }}'
 {% if mail is defined and mail is not none %}
 SPRING_MAIL_HOST='{{ mail.hostname }}'
 SPRING_MAIL_PORT='{{ mail.port }}'
+{% if mail.username is defined and mail.username is not none %}
 SPRING_MAIL_USERNAME='{{ mail.username }}'
+{% endif %}
+{% if mail.password is defined and mail.password is not none %}
 SPRING_MAIL_PASSWORD='{{ mail.password }}'
+{% endif %}
 SPRING_MAIL_PROTOCOL='{{ mail.protocol }}'
-SPRING_MAIL_TLS='true'
-SPRING_MAIL_PROPERTIES_MAIL_SMTP_AUTH='true'
-SPRING_MAIL_PROPERTIES_MAIL_SMTP_STARTTLS_ENABLE='true'
+SPRING_MAIL_TLS='{{ mail.tls | default(true) | to_json }}'
+SPRING_MAIL_PROPERTIES_MAIL_SMTP_AUTH='{{ mail.smtp_auth | default(true) | to_json }}'
+SPRING_MAIL_PROPERTIES_MAIL_SMTP_SSL_ENABLE='{{ mail.smtp_ssl_enable | default(false) | to_json }}'
+SPRING_MAIL_PROPERTIES_MAIL_SMTP_STARTTLS_ENABLE='{{ mail.smtp_starttls_enable | default(true) | to_json }}'
 SPRING_MAIL_PROPERTIES_MAIL_SMTP_SSL_TRUST='{{ mail.ssl_trust }}'
 {% endif %}
 SERVER_PORT='{{ artemis_server_port }}'


### PR DESCRIPTION
### Summary

Adds more configuration variables for a wider range of mail server configurations and thereby removes hard-coded configurations. All hard-coded configurations are replicated with default values of the configuration variables.
Username and password is made optional completely and an additional configuration for enabling SSL is provided.

### Motivation

Some mail server configurations might need specific configurations which don't fit the hard-coded configuration provided.
By adding these configuration variables and also adding default values that resemble the previously set values, these changes widen the configurability.

### Testing

Due to the default values of the new configuration variables, these changes should not affect existing installations.

Closes #209

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
* Mail and SMTP configuration is now conditional and parameterized across deployment environments.
* Username and password fields are only included when explicitly defined, reducing configuration noise.
* TLS, authentication, SSL, and STARTTLS settings can now be customized per deployment instead of using fixed defaults, providing greater flexibility for different deployment scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->