### PR TITLE
weaviate role: configurable embedder (drop hardcoded multi2vec-clip), pin Weaviate 1.37.9

### DIFF
--- a/roles/weaviate/README.md
+++ b/roles/weaviate/README.md
@@ -1,18 +1,30 @@
 # Weaviate
 
-This role deploys a shared Weaviate vector database instance with Traefik reverse proxy and automatic HTTPS via Let's Encrypt. The role supports single node installations via Docker Compose.
+This role deploys a shared Weaviate vector database instance with Traefik reverse proxy and automatic HTTPS via Let's Encrypt. The role supports single-node installations via Docker Compose.
+
+This is the **Ansible provisioning path** referenced from the Artemis admin guide for global search:
+[https://docs.artemis.cit.tum.de/admin/global-search-weaviate](https://docs.artemis.cit.tum.de/admin/global-search-weaviate)
 
 ## Description
 
 This role sets up a production-ready Weaviate deployment that includes:
 
-- **Weaviate**: Vector database for AI/ML applications
+- **Weaviate**: Vector database for AI/ML applications (pinned to `1.37.9`)
 - **Traefik**: Reverse proxy with automatic SSL/TLS certificate management
-- **Multi2vec-CLIP**: Vector embedding module for multimodal search
-- **Automated Backups**: Configurable scheduled backups with retention policies
+- **Server-side vectorization** (configurable via `weaviate_embedder`; see below)
+- **Automated Backups**: Always-enabled `backup-filesystem` module with configurable schedule and retention
 - **Security Features**: API key authentication, IP whitelisting, rate limiting, HTTPS enforcement
 
 The setup is based on the [edutelligence repository](https://github.com/ls1intum/edutelligence) shared Weaviate infrastructure.
+
+### Relationship to Artemis and Pyris/Atlas
+
+This role serves two distinct usage patterns:
+
+| Consumer | Pattern | `weaviate_embedder` |
+|---|---|---|
+| **Artemis global search** | Server-side vectorization: Artemis sends plain text; Weaviate embeds it using `text2vec-openai` (cloud OpenAI or a self-hosted OpenAI-compatible endpoint, e.g. Qwen). | `openai` (default) |
+| **Pyris / AtlasML** | Client-side (self-provided) vectors: Pyris or Atlas embeds content itself and uploads pre-computed vectors. Weaviate stores and indexes them but performs no vectorization. | `none` |
 
 ## Prerequisites
 
@@ -24,7 +36,7 @@ Before using this role, ensure the following requirements are met:
 - **Docker Engine**: 20.10 or later
 - **Docker Compose**: v2.0 or later
 - **Ports**: 80, 443, and 50051 must be accessible from the internet
-- **Resources**: Minimum 8GB RAM, 4 CPU cores recommended
+- **Resources**: Minimum 8 GB RAM, 4 CPU cores recommended
 
 ### DNS Configuration
 
@@ -42,7 +54,7 @@ This role **does not** install Docker. You must install Docker and Docker Compos
 
 ## Configuration
 
-To configure the role, you need to set the required variables in your Ansible playbook or inventory.
+To configure the role, set the required variables in your Ansible playbook or inventory.
 
 ### Required Variables
 
@@ -66,8 +78,28 @@ Default variables can be found in the [defaults/main.yml](defaults/main.yml) fil
 #### Version and Paths
 
 ```yaml
-weaviate_build_version: "1.30.0"
+# Weaviate version pin — do not change unless you have tested the migration
+weaviate_build_version: "1.37.9"
 weaviate_working_directory: "/opt/weaviate"
+```
+
+#### Embedder / Vectorizer Selection
+
+```yaml
+# Controls which server-side vectorizer (ENABLE_MODULES) Weaviate loads.
+#
+# Supported values:
+#   openai       — text2vec-openai (default). Use for Artemis global search with cloud
+#                  OpenAI or a self-hosted OpenAI-compatible endpoint (e.g. Qwen).
+#   none         — No server vectorizer. Consumers such as Pyris and AtlasML supply
+#                  pre-computed vectors themselves.
+#   clip         — multi2vec-clip (opt-in only; legacy multimodal use cases).
+#                  Starts an additional inference sidecar container. Not needed for
+#                  Artemis text search or Pyris/Atlas.
+#
+# Note: local CPU embedding via transformers (embeddinggemma) is planned but is
+#       NOT yet supported by this role.
+weaviate_embedder: "openai"
 ```
 
 #### User Management
@@ -92,8 +124,10 @@ weaviate_allowed_ips: ""
 
 #### Automated Backups
 
+The `backup-filesystem` Weaviate module is **always enabled** by this role. The variables below control the cron-driven automated backup job:
+
 ```yaml
-# Enable automated backups
+# Enable automated backups via cron
 weaviate_enable_automated_backups: true
 
 # Backup schedule (cron format) - default: daily at 2 AM
@@ -107,23 +141,23 @@ weaviate_backup_retention_days: 7
 
 ```yaml
 # Weaviate container resources
-weaviate_cpu_limit: "8"
-weaviate_memory_limit: "16G"
+weaviate_cpu_limit: "2"
+weaviate_memory_limit: "4G"
 
 # Traefik resources
 weaviate_traefik_cpu_limit: "1"
-weaviate_traefik_memory_limit: "1G"
+weaviate_traefik_memory_limit: "512M"
 
-# Multi2vec-CLIP resources
-weaviate_multi2vec_cpu_limit: "4"
-weaviate_multi2vec_memory_limit: "8G"
+# Multi2vec-CLIP resources (opt-in only; only used when weaviate_embedder: clip)
+weaviate_multi2vec_cpu_limit: "1"   # opt-in only
+weaviate_multi2vec_memory_limit: "2G"  # opt-in only
 ```
 
 ## Example Usage
 
-### Basic Single Node Installation
+### Artemis Global Search (default — OpenAI vectorizer)
 
-Here is an example playbook for a single node installation:
+Standard deployment for Artemis server-side text vectorization:
 
 ```yaml
 - hosts: weaviate
@@ -133,6 +167,22 @@ Here is an example playbook for a single node installation:
         weaviate_domain: "weaviate.example.com"
         weaviate_api_key: "your-secure-api-key-here"
         letsencrypt_email: "admin@example.com"
+        # weaviate_embedder defaults to "openai" — no need to set it explicitly
+```
+
+### Pyris / AtlasML (client-provided vectors — no server vectorizer)
+
+Use this when Pyris or AtlasML will supply pre-computed vectors:
+
+```yaml
+- hosts: weaviate
+  roles:
+    - role: ls1intum.artemis.weaviate
+      vars:
+        weaviate_domain: "weaviate.example.com"
+        weaviate_api_key: "your-secure-api-key-here"
+        letsencrypt_email: "admin@example.com"
+        weaviate_embedder: "none"
 ```
 
 ### Advanced Configuration with IP Whitelisting
@@ -209,6 +259,8 @@ The role installs a helper script at `/opt/weaviate/weaviate-docker.sh` with the
 
 ## Backup and Restore
 
+The `backup-filesystem` Weaviate module is always enabled; it allows Weaviate-native backups to the local filesystem.
+
 ### Manual Backup
 
 Create a manual backup:
@@ -254,7 +306,7 @@ To update Weaviate to a new version:
 1. **Update the version variable** in your playbook or inventory:
 
    ```yaml
-   weaviate_build_version: "1.31.0"  # New version
+   weaviate_build_version: "1.38.0"  # New version
    ```
 
 2. **Re-run the Ansible playbook**:
@@ -335,10 +387,10 @@ If unable to connect to Weaviate:
 
 ### High Memory Usage
 
-Weaviate is configured with 16GB memory limit by default. If this is too high for your system:
+Weaviate is configured with 4 GB memory limit by default. If this is too high for your system:
 
 ```yaml
-weaviate_memory_limit: "8G"
+weaviate_memory_limit: "2G"
 ```
 
 ### Backup Failures
@@ -375,9 +427,10 @@ After deployment, the following structure exists:
 
 ## Related Documentation
 
+- [Artemis Admin Guide — Global Search / Weaviate](https://docs.artemis.cit.tum.de/admin/global-search-weaviate)
 - [Weaviate Documentation](https://weaviate.io/developers/weaviate)
 - [Traefik Documentation](https://doc.traefik.io/traefik/)
-- [edutelligence Repository](https://github.com/ls1intum/edutelligence) - Source of Weaviate setup
+- [edutelligence Repository](https://github.com/ls1intum/edutelligence) — Source of Weaviate setup
 - [Let's Encrypt Documentation](https://letsencrypt.org/docs/)
 
 ## License

--- a/roles/weaviate/defaults/main.yml
+++ b/roles/weaviate/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-weaviate_build_version: "1.30.0"
+weaviate_build_version: "1.37.9"
 weaviate_working_directory: "/opt/weaviate"
 weaviate_data_directory: "{{ weaviate_working_directory }}/data"
 weaviate_traefik_directory: "{{ weaviate_working_directory }}/traefik"
@@ -13,6 +13,17 @@ weaviate_user_name: "weaviate"
 weaviate_user_group: "weaviate"
 weaviate_user_uid: "1339"
 weaviate_user_gid: "1339"
+
+##############################################################################
+# Embedder / Vectorizer Selection
+##############################################################################
+
+# Embedder mode for Weaviate's server-side vectorizer.
+#   openai -> text2vec-openai (cloud OpenAI or self-hosted OpenAI-compatible, e.g. Qwen)
+#   none   -> no server vectorizer (consumers self-provide vectors, e.g. Pyris/Atlas)
+#   clip   -> multi2vec-clip (opt-in only; legacy multimodal)
+#   (transformers / local-CPU embeddinggemma is planned but NOT yet supported by this role)
+weaviate_embedder: "openai"
 
 ##############################################################################
 # Weaviate Configuration
@@ -43,6 +54,7 @@ weaviate_allowed_ips: ""
 
 ##############################################################################
 # Multi2vec-CLIP Configuration
+# Only used when weaviate_embedder: clip (opt-in; not the default)
 ##############################################################################
 
 weaviate_multi2vec_image: "cr.weaviate.io/semitechnologies/multi2vec-clip:sentence-transformers-clip-ViT-B-32-multilingual-v1"
@@ -61,7 +73,7 @@ weaviate_traefik_memory_limit: "512M"
 weaviate_cpu_limit: "2"
 weaviate_memory_limit: "4G"
 
-# Multi2vec-CLIP Resources
+# Multi2vec-CLIP Resources (only used when weaviate_embedder: clip; opt-in, not the default)
 weaviate_multi2vec_cpu_limit: "1"
 weaviate_multi2vec_memory_limit: "2G"
 

--- a/roles/weaviate/tasks/main.yml
+++ b/roles/weaviate/tasks/main.yml
@@ -13,6 +13,11 @@
         - weaviate_api_key (generate with: openssl rand -base64 32)
         - letsencrypt_email (e.g., your-email@example.com)
 
+- name: Validate weaviate_embedder
+  ansible.builtin.assert:
+    that: weaviate_embedder in ['openai', 'none', 'clip']
+    fail_msg: "weaviate_embedder must be one of openai|none|clip (transformers not yet supported by this role)"
+
 - name: Ensure weaviate group {{ weaviate_user_group }} exists
   become: true
   group:

--- a/roles/weaviate/templates/docker-compose.yml.j2
+++ b/roles/weaviate/templates/docker-compose.yml.j2
@@ -59,9 +59,14 @@ services:
       AUTHENTICATION_APIKEY_ALLOWED_KEYS: '${WEAVIATE_API_KEY}'
       AUTHENTICATION_APIKEY_USERS: '${WEAVIATE_API_USER:-{{ weaviate_api_user }}}'
       PERSISTENCE_DATA_PATH: '/var/lib/weaviate'
-      ENABLE_MODULES: 'multi2vec-clip,text2vec-openai,backup-filesystem'
+{% set _modmap = {'openai': 'text2vec-openai', 'clip': 'multi2vec-clip', 'none': ''} %}
+{% set _mod = _modmap[weaviate_embedder] %}
+{% set _mods = ([_mod] if _mod else []) + ['backup-filesystem'] %}
+      ENABLE_MODULES: '{{ _mods | join(",") }}'
       ENABLE_API_BASED_MODULES: 'true'
+{% if weaviate_embedder == 'clip' %}
       CLIP_INFERENCE_API: 'http://multi2vec-clip:8080'
+{% endif %}
       CLUSTER_HOSTNAME: 'node1'
       LOG_LEVEL: '${WEAVIATE_LOG_LEVEL:-{{ weaviate_log_level }}}'
       LOG_FORMAT: 'json'
@@ -104,10 +109,13 @@ services:
         reservations:
           cpus: '{{ weaviate_cpu_limit }}'
           memory: {{ weaviate_memory_limit }}
+{% if weaviate_embedder == 'clip' %}
     depends_on:
       multi2vec-clip:
         condition: service_started
+{% endif %}
 
+{% if weaviate_embedder == 'clip' %}
   multi2vec-clip:
     image: {{ weaviate_multi2vec_image }}
     container_name: multi2vec-clip
@@ -126,6 +134,7 @@ services:
         reservations:
           cpus: '{{ weaviate_multi2vec_cpu_limit }}'
           memory: {{ weaviate_multi2vec_memory_limit }}
+{% endif %}
 
 networks:
   weaviate_network:

--- a/roles/weaviate/templates/weaviate-docker.sh.j2
+++ b/roles/weaviate/templates/weaviate-docker.sh.j2
@@ -11,7 +11,7 @@ Usage:
   ./$(basename "$0") <command> [options]
 
 Commands:
-  start                           Start Weaviate, Traefik and multi2vec-clip
+  start                           Start Weaviate, Traefik{% if weaviate_embedder == 'clip' %} and multi2vec-clip{% endif %}
   stop                            Stop all Weaviate services
   restart                         Restart all Weaviate services
   logs [service]                  Show logs (optionally for specific service)


### PR DESCRIPTION
## Motivation

The `weaviate` role hardcoded `ENABLE_MODULES: 'multi2vec-clip,...'` and always ran a `multi2vec-clip` sidecar — a multimodal CLIP embedder that **neither** Artemis global search nor Pyris/Atlas actually use (they use `text2vec-openai` / self-provided vectors). It also pinned Weaviate `1.30.0`.

## Description

- Added a **`weaviate_embedder`** variable (default `openai`; supported `openai` | `none` | `clip`; `transformers`/local-CPU is documented as planned-not-yet-supported and rejected by an assert).
- `ENABLE_MODULES` is now **derived** from it, always retaining `backup-filesystem` (the backup scripts depend on it). `multi2vec-clip` is **opt-in only** — its service + `depends_on` are gated behind `weaviate_embedder == 'clip'`, so the default and `none`/`openai` modes contain zero CLIP references.
- Bumped the Weaviate pin to **1.37.9**; updated the helper script's usage text and the README (documents the variable, the Artemis-vs-Pyris/Atlas architecture, and the 1.37.9 pin).

## Testing

- `ansible-lint roles/weaviate` clean.
- Rendered `docker-compose.yml.j2` for all three modes and validated each with `docker compose config`: `openai` → `text2vec-openai,backup-filesystem`; `none` → `backup-filesystem`; `clip` → `multi2vec-clip,backup-filesystem` + sidecar. `openai`/`none` contain no `multi2vec-clip`; only `clip` does.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable embedder selection with OpenAI, CLIP, or client-provided vector options.

* **Updates**
  * Upgraded Weaviate to a newer version.
  * Enhanced default security configuration with API key authentication and HTTPS enforcement.
  * Made filesystem backups always enabled by default.
  * Updated documentation with production-ready deployment guidance and clearer configuration instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->