### PR TITLE
`Development`: Add feature toggle to hermes role for setup/deployment separation

### DIFF
--- a/roles/hermes/handlers/main.yml
+++ b/roles/hermes/handlers/main.yml
@@ -3,4 +3,5 @@
   community.docker.docker_compose_v2:
     project_src: "{{ hermes_working_directory }}"
     state: present
+    pull: always
   become: true

--- a/roles/hermes/tasks/main.yml
+++ b/roles/hermes/tasks/main.yml
@@ -12,6 +12,15 @@
     dest: "{{ hermes_working_directory }}/docker-compose.yml"
     mode: '600'
   notify: Restart hermes
+  when: setup_system
+
+- name: Update version in docker-compose file
+  become: true
+  lineinfile:
+    path: "{{ hermes_working_directory }}/docker-compose.yml"
+    regexp: '^    image: ghcr.io/ls1intum/hermes:.*$'
+    line: "    image: ghcr.io/ls1intum/hermes:{{ hermes_version }}"
+  when: not setup_system
 
 - name: Create Google certificate file
   ansible.builtin.copy:

--- a/roles/hermes/tasks/main.yml
+++ b/roles/hermes/tasks/main.yml
@@ -10,25 +10,27 @@
   template:
     src: "docker-compose.yml.j2"
     dest: "{{ hermes_working_directory }}/docker-compose.yml"
-    mode: '0600'
+    mode: '600'
   notify: Restart hermes
 
 - name: Create Google certificate file
   ansible.builtin.copy:
     content: "{{ hermes_google_application_credentials_content }}"
     dest: "{{ hermes_working_directory }}/{{ hermes_google_application_credentials_json_path }}"
-    mode: "0600"
+    mode: "600"
     owner: "root"
     group: "root"
   become: true
   notify: Restart hermes
+  when: setup_system
 
 - name: Create Apple certificate file
   ansible.builtin.copy:
     content: "{{ hermes_apns_certificate_content | b64decode }}"
     dest: "{{ hermes_working_directory }}/{{ hermes_apns_certificate_path }}"
-    mode: "0600"
+    mode: "600"
     owner: "root"
     group: "root"
   become: true
   notify: Restart hermes
+  when: setup_system


### PR DESCRIPTION
### Motivation
The Hermes role recreated the Google and Apple certificate files on every run, regardless of whether a full system setup was being performed. This gated certificate provisioning behind `setup_system`, consistent with how the `artemis` role already treats system-level setup tasks.

### Changes
- Gate the **Create Google certificate file** and **Create Apple certificate file** tasks behind `when: setup_system`, so credentials are only written during a system setup run (matching the existing `setup_system` pattern in the `artemis` role).
- Normalize file `mode` values from `'0600'` / `"0600"` to `'600'` / `"600"` for the docker-compose and certificate files.

### Affected files
- `roles/hermes/tasks/main.yml`

### Testing
- [ ] Verified Hermes deploys to staging
- [ ] Verified Hermes deploys to prod