### PR TITLE
Notify Restart hermes on version/config changes during deploys

### DIFF
--- a/roles/hermes/tasks/main.yml
+++ b/roles/hermes/tasks/main.yml
@@ -20,6 +20,7 @@
     path: "{{ hermes_working_directory }}/docker-compose.yml"
     regexp: '^    image: ghcr.io/ls1intum/hermes:.*$'
     line: "    image: ghcr.io/ls1intum/hermes:{{ hermes_version }}"
+  notify: Restart hermes
   when: not setup_system
 
 - name: Create Google certificate file


### PR DESCRIPTION
## Summary
- The `Update version in docker-compose file` task now notifies `Restart hermes`, so deploys (`setup_system=false`) that bump `hermes_version` actually recreate the container instead of leaving the old image running.
- The handler runs `docker_compose_v2` with `pull: always`, so once it's notified a new image tag is pulled and the container is recreated.
- Branch also bundles the prior setup work (hermes deploy prod/staging plays, lineinfile-based version replacement, and `pull: always` on the handler).

## Test plan
- [ ] Run a deploy with a bumped `hermes_version` against staging and confirm the hermes container is recreated on the new image.
- [ ] Run a deploy with the same `hermes_version` and confirm no restart happens (handler not notified).
- [ ] Run a full `setup_system` play and confirm the compose file/certs are written and hermes starts cleanly.