### PR TITLE
Add optional WAR extraction for faster startup and reduced downtime

### DIFF
--- a/roles/artemis/defaults/main.yml
+++ b/roles/artemis/defaults/main.yml
@@ -62,6 +62,17 @@ artemis_telemetry_destination: "https://telemetry.artemis.cit.tum.de"
 artemis_working_directory: "/opt/artemis"
 artemis_repo_basepath: "."
 
+# When enabled, the deployed WAR is extracted (exploded) into an on-disk layout that Artemis
+# runs from directly (java -jar app/artemis.war with a flat lib/), instead of the packed WAR.
+# This avoids Spring Boot's nested-jar classloader, which dominates cold start, cutting startup
+# from ~38s to ~25s. The extraction runs once per deploy while the OLD instance is still serving
+# (see copy_artemis_executable.yml), so the ~13s saving comes off the downtime window, not just
+# total deploy time. Opt-in per environment (enable in group_vars) so it can be validated on a
+# staging cluster before production.
+artemis_extract_war: false
+# Directory the exploded layout is activated into (staged as "<dir>.new" before the swap).
+artemis_extracted_app_directory: "{{ artemis_working_directory }}/app"
+
 artemis_legal_path: /opt/artemis/legal
 artemis_data_export_path: /opt/artemis/data-exports
 artemis_tmp_directory: # Defaults to system tmp dir

--- a/roles/artemis/tasks/activate_extracted_war.yml
+++ b/roles/artemis/tasks/activate_extracted_war.yml
@@ -1,0 +1,29 @@
+---
+# Activate the exploded layout for the Artemis service, during the stopped window.
+# Normal path: a fast local swap of the layout that copy_artemis_executable.yml pre-extracted
+# into "<app>.new" while the old instance was still running. The previous layout is kept as
+# "<app>.old" for rollback, mirroring the artemis.war -> artemis.war.old backup.
+#
+# Fallback path: if extraction is enabled but no pre-extracted layout is present (for example
+# the flag was turned on via a config-only update without a new WAR download), extract the
+# current packed WAR so the unit can start from the exploded layout. This only triggers when
+# the exploded layout is missing, so plain restarts stay a no-op.
+- name: Activate extracted WAR layout
+  become: true
+  ansible.builtin.shell: |
+    set -euo pipefail
+    app="{{ artemis_extracted_app_directory }}"
+    if [ -d "$app.new" ]; then
+      rm -rf "$app.old"
+      if [ -d "$app" ]; then mv "$app" "$app.old"; fi
+      mv "$app.new" "$app"
+    elif [ ! -e "$app/artemis.war" ] && [ -f "{{ artemis_working_directory }}/artemis.war" ]; then
+      rm -rf "$app"
+      /usr/bin/java -Djarmode=tools -jar "{{ artemis_working_directory }}/artemis.war" extract --destination "$app"
+      chown -R {{ artemis_user_name }}:{{ artemis_user_group }} "$app"
+    fi
+  args:
+    executable: /bin/bash
+  when:
+    - artemis_extract_war | bool
+    - not ansible_check_mode

--- a/roles/artemis/tasks/copy_artemis_executable.yml
+++ b/roles/artemis/tasks/copy_artemis_executable.yml
@@ -47,3 +47,29 @@
     mode: "644"
     force: true
   when: is_release | bool
+
+# Pre-extract the freshly staged WAR into an exploded layout while the currently running instance
+# keeps serving. Running from the exploded layout (java -jar app/artemis.war) avoids Spring Boot's
+# nested-jar classloader, which dominates cold start (~38s -> ~25s). Doing the extraction here, before
+# restart_artemis.yml stops the service, keeps the ~9s extraction out of the downtime window; only the
+# fast swap into place happens while the service is down. Spring Boot's `extract` rejects a `.war.new`
+# source name, so the staged file is first copied to a real `.war` name. Runs as root and hands the
+# result to the service user so the artemis unit can read it.
+- name: Pre-extract new WAR into an exploded layout (old instance keeps running)
+  become: true
+  ansible.builtin.shell: |
+    set -euo pipefail
+    src="{{ artemis_working_directory }}/artemis-extract-src.war"
+    dest="{{ artemis_extracted_app_directory }}.new"
+    rm -rf "$dest" "$src"
+    cp "{{ artemis_working_directory }}/artemis.war.new" "$src"
+    /usr/bin/java -Djarmode=tools -jar "$src" extract --destination "$dest"
+    mv "$dest/artemis-extract-src.war" "$dest/artemis.war"
+    rm -f "$src"
+    chown -R {{ artemis_user_name }}:{{ artemis_user_group }} "$dest"
+  args:
+    executable: /bin/bash
+  when:
+    - download_artemis_application | bool
+    - artemis_extract_war | bool
+    - not ansible_check_mode

--- a/roles/artemis/tasks/restart_artemis.yml
+++ b/roles/artemis/tasks/restart_artemis.yml
@@ -58,6 +58,11 @@
     - node_id is defined
     - node_id == 1
 
+- include_tasks: activate_extracted_war.yml
+  when:
+    - node_id is defined
+    - node_id == 1
+
 - name: Start artemis on node 1
   become: true
   service:
@@ -99,6 +104,10 @@
     - node_id == 1
     - not ansible_check_mode
   throttle: 1
+
+- include_tasks: activate_extracted_war.yml
+  when:
+    - node_id is undefined or not (node_id == 1)
 
 - name: Start artemis on other nodes
   become: true

--- a/roles/artemis/templates/artemis.service.j2
+++ b/roles/artemis/templates/artemis.service.j2
@@ -25,7 +25,11 @@ ExecStart=/usr/bin/java \
     --add-opens java.base/sun.nio.ch=ALL-UNNAMED \
     --add-opens java.management/sun.management=ALL-UNNAMED \
     --add-opens jdk.management/com.sun.management.internal=ALL-UNNAMED \
+{% if artemis_extract_war | default(false) | bool %}
+    -jar {{ artemis_extracted_app_directory }}/artemis.war \
+{% else %}
     -jar artemis.war \
+{% endif %}
     --spring.profiles.active={{ artemis_spring_profiles }}
 SuccessExitStatus=143
 #StandardOutput=file:{{ artemis_working_directory }}/artemis.log


### PR DESCRIPTION
## Summary
Add an opt-in `artemis_extract_war` (default: **false**) that deploys Artemis from an **extracted (exploded) WAR** instead of the packed WAR. This cuts cold start from ~38s to ~25s and, because the extraction happens while the old instance is still serving, removes ~13s from the deploy **downtime** window.

## Motivation
Spring Boot's nested-jar classloader dominates Artemis cold start (JFR: ~40% of boot CPU is `jar:nested:` URL/zip resolution across ~470 nested jars). Running from an exploded layout (a flat `lib/` of real files) avoids it. Doing the extraction before the service is stopped keeps its ~9s cost out of the downtime window, so only a fast directory swap happens while Artemis is down. This is the bare-metal half of the effort; the Docker half is a separate PR in the Artemis repo.

## Changes
- **`defaults/main.yml`**: `artemis_extract_war` (default `false`) + `artemis_extracted_app_directory`.
- **`copy_artemis_executable.yml`**: after staging `artemis.war.new`, pre-extract it into `app.new` **while the old instance keeps running**. (Spring Boot's `extract` rejects a `.war.new` filename, so the file is copied to a real `.war` name first; runs as root and hands the result to the service user.)
- **`activate_extracted_war.yml`** (new): during the stopped window, swap `app.new` → `app` (fast local move). The previous layout is kept as `app.old` for rollback, mirroring the existing `artemis.war.old` backup.
- **`artemis.service.j2`**: when enabled, the unit runs `-jar {{ artemis_extracted_app_directory }}/artemis.war`; otherwise unchanged (`-jar artemis.war`).
- **`restart_artemis.yml`**: activate the extracted layout on node 1 and on the other nodes before their respective service start.

Default is off so it can be validated on a staging cluster before being enabled in production `group_vars`.

## Testing
- YAML validated for all changed task files.
- Extraction mechanism and timing verified on a staging node: extract ~8.7s (one-time, while old instance serves), startup ~25s vs ~38s packed.
- **End-to-end validation still needed**: set `artemis_extract_war: true` for a staging cluster, run a deploy, and confirm shorter downtime, healthy startup from the exploded layout, and that `app.old` is present for rollback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional exploded deployment mode for the application.
  * Introduced configurable defaults to enable WAR extraction and define the extracted app directory.
  * Pre-extracts the updated WAR into an exploded layout while the service continues running.
* **Bug Fixes**
  * Improved restart sequencing to safely activate pre-extracted layouts during service restarts.
  * Updated the service configuration to use the correct WAR source when exploded mode is enabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->