### PR TITLE
Fix build agent startup on Spring Boot 4 and scope Theia to core nodes

### DIFF
--- a/roles/artemis/templates/application-prod.yml.j2
+++ b/roles/artemis/templates/application-prod.yml.j2
@@ -93,17 +93,12 @@ spring:
 {% else %}
   liquibase:
       enabled: false #not needed for build agents
-  autoconfigure:
-      exclude:
-          # Hibernate and DataSource are not needed in the build agent
-          - org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfiguration
-          - org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration
-          # Those metrics are repeated here, because overriding the `exclude` array is not possible
-          - org.springframework.boot.actuate.autoconfigure.metrics.data.RepositoryMetricsAutoConfiguration
-          - org.springframework.boot.actuate.autoconfigure.metrics.jdbc.DataSourcePoolMetricsAutoConfiguration
-          - org.springframework.boot.actuate.autoconfigure.metrics.startup.StartupTimeMetricsListenerAutoConfiguration
-          - org.springframework.boot.actuate.autoconfigure.metrics.task.TaskExecutorMetricsAutoConfiguration
-          - org.springframework.boot.actuate.autoconfigure.metrics.web.tomcat.TomcatMetricsAutoConfiguration
+  # Hibernate, DataSource and the related metrics auto-configurations are excluded for build agents by
+  # the WAR-bundled config/application-buildagent.yml (active whenever the "buildagent" profile is set).
+  # Do NOT repeat spring.autoconfigure.exclude here: this external file outranks the bundled config and
+  # the exclude list replaces rather than merges, so a stale copy silently overrides the WAR list. That
+  # is exactly what broke every prod build agent when the Spring Boot 4 upgrade relocated these classes
+  # but this template kept the old package names.
 {% endif %}
 
 
@@ -406,7 +401,7 @@ artemis:
 {% endif %}
 {% endif %}
 
-{% if theia is defined and theia is not none %}
+{% if artemis_computed_is_core_node and theia is defined and theia is not none %}
   theia:
     enabled: true
 {% if theia.portal_url is defined and theia.portal_url is not none %}

--- a/roles/artemis/templates/artemis.env.j2
+++ b/roles/artemis/templates/artemis.env.j2
@@ -276,7 +276,7 @@ ARTEMIS_TELEMETRY_DESTINATION='{{ artemis_telemetry_destination }}'
 ARTEMIS_LICENSES_MATLAB_LICENSESERVER='{{ licenses.matlab }}'
 {% endif %}
 {% endif %}
-{% if theia is defined and theia is not none %}
+{% if artemis_computed_is_core_node and theia is defined and theia is not none %}
 ARTEMIS_THEIA_ENABLED='true'
 {% if theia.portal_url is defined and theia.portal_url is not none %}
 ARTEMIS_THEIA_PORTALURL='{{ theia.portal_url }}'


### PR DESCRIPTION
## Problem

On 2026-07-07 all 20 production build agents (`agent01`–`agent20`) crash-looped on startup with:

```
Unable to determine Dialect without JDBC metadata (please set 'jakarta.persistence.jdbc.url' ...)
```

The build-agent branch of `application-prod.yml.j2` duplicated `spring.autoconfigure.exclude` using the **Spring Boot 3** package names (`org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfiguration`, etc.). After the Spring Boot 4 upgrade relocated those auto-configuration classes (`org.springframework.boot.hibernate.autoconfigure.*`), the WAR-bundled `config/application-buildagent.yml` was updated but this ansible template was not.

Because the rendered external `/opt/artemis/application-prod.yml` outranks the WAR-bundled config, and `spring.autoconfigure.exclude` **replaces rather than merges**, the stale (now unresolvable) list won and `HibernateJpaAutoConfiguration` was no longer excluded. Hibernate then bootstrapped with no datasource and the JDBC-metadata probe disabled (production speed-up from Artemis #13013), so it could not determine the dialect and the context failed. Core nodes were unaffected (they render the datasource + dialect, not the exclude block).

## Fix

- **Remove the duplicated exclude block** from the build-agent branch of `application-prod.yml.j2`. The WAR-bundled `application-buildagent.yml` (loaded whenever the `buildagent` profile is active) already carries the correct Spring Boot 4 exclusion list and is now the single source of truth, immune to future package renames.
- **Gate the Theia online-IDE config** (`application-prod.yml.j2` and `artemis.env.j2`) behind `artemis_computed_is_core_node`, so it is never enabled on build agents, which do not serve the IDE.

## Deployment note

Production was already recovered out-of-band by correcting the class names on each agent's `/opt/artemis/application-prod.yml` and restarting. Once this template is deployed, the external file no longer declares the exclusions and the WAR config takes over cleanly (verified: CI/dev build agents run with only `application-buildagent.yml`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved production configuration handling for core vs. non-core nodes.
  * Theia settings now appear only on core nodes, avoiding unintended configuration on other deployments.
  * Build-agent deployments no longer repeat exclusion settings in the production template; guidance is left in comments instead.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->