### PR TITLE
`Development`: Add configuration layout for OpenID Connect (OIDC) authentication

### DIFF
--- a/roles/artemis/README.md
+++ b/roles/artemis/README.md
@@ -43,6 +43,17 @@ ldap:
   password: "your_ldap_password"
 ```
 
+OIDC login configuration (e.g. TUM Login, an alternative to LDAP):
+```
+artemis_oidc:
+  enabled: true
+  button_label: "TUM Login"
+  client_id: "your_client_id"
+  client_secret: "your_client_secret"
+  issuer_uri: "https://login.example.com"
+```
+You can provide `authorization_uri`, `token_uri`, `user_info_uri`, and `jwk_set_uri` individually. Claim mappings default to standard OIDC claims and can be overridden via `mappings.*`.
+
 To allow internal user registration:
 ```
 user_management:

--- a/roles/artemis/defaults/main.yml
+++ b/roles/artemis/defaults/main.yml
@@ -134,22 +134,24 @@ artemis_external_password_reset_link_de: "https://campus.tum.de/tumonline/co_loc
 artemis_passkey_enabled: false
 artemis_passkey_require_for_administrator_features: false
 
-artemis_oidc:
-  enabled: false
-  button_label: "TUM Login"
-  client_id: ""
-  client_secret: ""
-  issuer_uri: ""
-  authorization_uri: ""
-  token_uri: ""
-  user_info_uri: ""
-  jwk_set_uri: ""
-  mappings:
-    username: "preferred_username"
-    matriculation_number: "matriculation_number"
-    first_name: "given_name"
-    last_name: "family_name"
-    email: "email"
+
+# OIDC / OAuth2 login (e.g. TUM Login). Alternative to LDAP for external authentication.
+#artemis_oidc:
+#  enabled: false
+#  button_label: "TUM Login"
+#  client_id: ""
+#  client_secret: ""
+#  issuer_uri: ""
+#  authorization_uri: ""
+#  token_uri: ""
+#  user_info_uri: ""
+#  jwk_set_uri: ""
+#  mappings:
+#    username: "preferred_username"
+#    matriculation_number: "matriculation_number"
+#    first_name: "given_name"
+#    last_name: "family_name"
+#    email: "email"
 
 #artemis_global_search_enabled: false
 

--- a/roles/artemis/defaults/main.yml
+++ b/roles/artemis/defaults/main.yml
@@ -134,6 +134,23 @@ artemis_external_password_reset_link_de: "https://campus.tum.de/tumonline/co_loc
 artemis_passkey_enabled: false
 artemis_passkey_require_for_administrator_features: false
 
+artemis_oidc:
+  enabled: false
+  button_label: "TUM Login"
+  client_id: ""
+  client_secret: ""
+  issuer_uri: ""
+  authorization_uri: ""
+  token_uri: ""
+  user_info_uri: ""
+  jwk_set_uri: ""
+  mappings:
+    username: "preferred_username"
+    matriculation_number: "matriculation_number"
+    first_name: "given_name"
+    last_name: "family_name"
+    email: "email"
+
 #artemis_global_search_enabled: false
 
 #ldap:

--- a/roles/artemis/templates/application-prod.yml.j2
+++ b/roles/artemis/templates/application-prod.yml.j2
@@ -2,6 +2,26 @@
 
 spring:
 {% if artemis_computed_is_core_node %}
+{% if artemis_oidc is defined and artemis_oidc.enabled | default(false) %}
+  security:
+    oauth2:
+      client:
+        registration:
+          oidc:
+            client-id: {{ artemis_oidc.client_id | quote }}
+            client-secret: {{ artemis_oidc.client_secret | quote }}
+            scope:
+              - openid
+              - profile
+              - email
+        provider:
+          oidc:
+            issuer-uri: {{ artemis_oidc.issuer_uri | quote }}
+            authorization-uri: {{ artemis_oidc.authorization_uri | quote }}
+            token-uri: {{ artemis_oidc.token_uri | quote }}
+            user-info-uri: {{ artemis_oidc.user_info_uri | quote }}
+            jwk-set-uri: {{ artemis_oidc.jwk_set_uri | quote }}
+{% endif %}
   datasource:
     type: com.zaxxer.hikari.HikariDataSource
     url: jdbc:{{ artemis_database_type }}://{{ artemis_database_host }}:{{ artemis_database_port }}/{{ artemis_database_dbname }}?createDatabaseIfNotExist=true&useUnicode=true&characterEncoding=utf8&allowPublicKeyRetrieval=true&useSSL=false&useLegacyDatetimeCode=false&serverTimezone=UTC
@@ -150,6 +170,16 @@ artemis:
 {% if ldap.url is defined and ldap.url is not none%}
     use-external: true
 {% else %}
+{% if artemis_oidc is defined and artemis_oidc.enabled | default(false) %}
+    oidc:
+      enabled: true
+      mappings:
+        username: "{{ artemis_oidc.mappings.username | default('preferred_username') }}"
+        matriculation-number: "{{ artemis_oidc.mappings.matriculation_number | default('matriculation_number') }}"
+        first-name: "{{ artemis_oidc.mappings.first_name | default('given_name') }}"
+        last-name: "{{ artemis_oidc.mappings.last_name | default('family_name') }}"
+        email: "{{ artemis_oidc.mappings.email | default('email') }}"
+{% endif %}
     use-external: false
 {% endif %}
 {% if artemis_passkey_enabled %}
@@ -498,6 +528,10 @@ info:
 {% endif %}
   textAssessmentAnalyticsEnabled: true
   localLLMDeploymentEnabled: {{ artemis_local_llm_deployment_enabled | lower }}
+{% if artemis_oidc is defined and artemis_oidc.enabled | default(false) %}
+  oidc:
+    buttonLabel: {{ artemis_oidc.button_label | default('TUM Login') | quote }}
+{% endif %}
   sentry:
 {% if sentry.dsn | default('') | length %}
     dsn: {{ sentry.dsn | quote }}

--- a/roles/artemis/templates/application-prod.yml.j2
+++ b/roles/artemis/templates/application-prod.yml.j2
@@ -184,11 +184,11 @@ artemis:
     oidc:
       enabled: true
       mappings:
-        username: "{{ artemis_oidc.mappings.username | default('preferred_username') }}"
-        matriculation-number: "{{ artemis_oidc.mappings.matriculation_number | default('matriculation_number') }}"
-        first-name: "{{ artemis_oidc.mappings.first_name | default('given_name') }}"
-        last-name: "{{ artemis_oidc.mappings.last_name | default('family_name') }}"
-        email: "{{ artemis_oidc.mappings.email | default('email') }}"
+        username: "{{ (artemis_oidc.mappings | default({})).username | default('preferred_username') }}"
+        matriculation-number: "{{ (artemis_oidc.mappings | default({})).matriculation_number | default('matriculation_number') }}"
+        first-name: "{{ (artemis_oidc.mappings | default({})).first_name | default('given_name') }}"
+        last-name: "{{ (artemis_oidc.mappings | default({})).last_name | default('family_name') }}"
+        email: "{{ (artemis_oidc.mappings | default({})).email | default('email') }}"
 {% endif %}
     use-external: false
 {% endif %}

--- a/roles/artemis/templates/application-prod.yml.j2
+++ b/roles/artemis/templates/application-prod.yml.j2
@@ -184,11 +184,11 @@ artemis:
     oidc:
       enabled: true
       mappings:
-        username: "{{ (artemis_oidc.mappings | default({})).username | default('preferred_username') }}"
-        matriculation-number: "{{ (artemis_oidc.mappings | default({})).matriculation_number | default('matriculation_number') }}"
-        first-name: "{{ (artemis_oidc.mappings | default({})).first_name | default('given_name') }}"
-        last-name: "{{ (artemis_oidc.mappings | default({})).last_name | default('family_name') }}"
-        email: "{{ (artemis_oidc.mappings | default({})).email | default('email') }}"
+        username: {{ (artemis_oidc.mappings | default({})).username | default('preferred_username') | to_json }}
+        matriculation-number: {{ (artemis_oidc.mappings | default({})).matriculation_number | default('matriculation_number') | to_json }}
+        first-name: {{ (artemis_oidc.mappings | default({})).first_name | default('given_name') | to_json }}
+        last-name: {{ (artemis_oidc.mappings | default({})).last_name | default('family_name') | to_json }}
+        email: {{ (artemis_oidc.mappings | default({})).email | default('email') | to_json }}
 {% endif %}
     use-external: false
 {% endif %}

--- a/roles/artemis/templates/application-prod.yml.j2
+++ b/roles/artemis/templates/application-prod.yml.j2
@@ -16,11 +16,21 @@ spring:
               - email
         provider:
           oidc:
+{% if artemis_oidc.issuer_uri | default('') | length > 0 %}
             issuer-uri: {{ artemis_oidc.issuer_uri | quote }}
+{% endif %}
+{% if artemis_oidc.authorization_uri | default('') | length > 0 %}
             authorization-uri: {{ artemis_oidc.authorization_uri | quote }}
+{% endif %}
+{% if artemis_oidc.token_uri | default('') | length > 0 %}
             token-uri: {{ artemis_oidc.token_uri | quote }}
+{% endif %}
+{% if artemis_oidc.user_info_uri | default('') | length > 0 %}
             user-info-uri: {{ artemis_oidc.user_info_uri | quote }}
+{% endif %}
+{% if artemis_oidc.jwk_set_uri | default('') | length > 0 %}
             jwk-set-uri: {{ artemis_oidc.jwk_set_uri | quote }}
+{% endif %}
 {% endif %}
   datasource:
     type: com.zaxxer.hikari.HikariDataSource

--- a/roles/artemis/templates/artemis.env.j2
+++ b/roles/artemis/templates/artemis.env.j2
@@ -52,6 +52,28 @@ SPRING_MAIL_PROPERTIES_MAIL_SMTP_SSL_ENABLE='{{ mail.smtp_ssl_enable | default(f
 SPRING_MAIL_PROPERTIES_MAIL_SMTP_STARTTLS_ENABLE='{{ mail.smtp_starttls_enable | default(true) | to_json }}'
 SPRING_MAIL_PROPERTIES_MAIL_SMTP_SSL_TRUST='{{ mail.ssl_trust }}'
 {% endif %}
+{% if artemis_oidc is defined and artemis_oidc.enabled | default(false) %}
+SPRING_SECURITY_OAUTH2_CLIENT_REGISTRATION_OIDC_CLIENTID='{{ artemis_oidc.client_id }}'
+SPRING_SECURITY_OAUTH2_CLIENT_REGISTRATION_OIDC_CLIENTSECRET='{{ artemis_oidc.client_secret }}'
+SPRING_SECURITY_OAUTH2_CLIENT_REGISTRATION_OIDC_SCOPE_0='openid'
+SPRING_SECURITY_OAUTH2_CLIENT_REGISTRATION_OIDC_SCOPE_1='profile'
+SPRING_SECURITY_OAUTH2_CLIENT_REGISTRATION_OIDC_SCOPE_2='email'
+{% if artemis_oidc.issuer_uri | default('') | length > 0 %}
+SPRING_SECURITY_OAUTH2_CLIENT_PROVIDER_OIDC_ISSUERURI='{{ artemis_oidc.issuer_uri }}'
+{% endif %}
+{% if artemis_oidc.authorization_uri | default('') | length > 0 %}
+SPRING_SECURITY_OAUTH2_CLIENT_PROVIDER_OIDC_AUTHORIZATIONURI='{{ artemis_oidc.authorization_uri }}'
+{% endif %}
+{% if artemis_oidc.token_uri | default('') | length > 0 %}
+SPRING_SECURITY_OAUTH2_CLIENT_PROVIDER_OIDC_TOKENURI='{{ artemis_oidc.token_uri }}'
+{% endif %}
+{% if artemis_oidc.user_info_uri | default('') | length > 0 %}
+SPRING_SECURITY_OAUTH2_CLIENT_PROVIDER_OIDC_USERINFOURI='{{ artemis_oidc.user_info_uri }}'
+{% endif %}
+{% if artemis_oidc.jwk_set_uri | default('') | length > 0 %}
+SPRING_SECURITY_OAUTH2_CLIENT_PROVIDER_OIDC_JWKSETURI='{{ artemis_oidc.jwk_set_uri }}'
+{% endif %}
+{% endif %}
 SERVER_PORT='{{ artemis_server_port }}'
 SERVER_URL='{{ artemis_server_url }}'
 SERVER_USEFORWARDHEADERS='true'
@@ -87,6 +109,14 @@ ARTEMIS_USERMANAGEMENT_LDAP_USERDN='{{ ldap.user_dn }}'
 ARTEMIS_USERMANAGEMENT_LDAP_BASE='{{ ldap.base }}'
 ARTEMIS_USERMANAGEMENT_LDAP_PASSWORD='{{ ldap.password }}'
 ARTEMIS_USERMANAGEMENT_LDAP_ALLOWEDUSERNAMEPATTERN='^([a-z]{2}\d{2}[a-z]{3})$'
+{% endif %}
+{% if artemis_oidc is defined and artemis_oidc.enabled | default(false) %}
+ARTEMIS_USERMANAGEMENT_OIDC_ENABLED='true'
+ARTEMIS_USERMANAGEMENT_OIDC_MAPPINGS_USERNAME='{{ (artemis_oidc.mappings | default({})).username | default('preferred_username') }}'
+ARTEMIS_USERMANAGEMENT_OIDC_MAPPINGS_MATRICULATIONNUMBER='{{ (artemis_oidc.mappings | default({})).matriculation_number | default('matriculation_number') }}'
+ARTEMIS_USERMANAGEMENT_OIDC_MAPPINGS_FIRSTNAME='{{ (artemis_oidc.mappings | default({})).first_name | default('given_name') }}'
+ARTEMIS_USERMANAGEMENT_OIDC_MAPPINGS_LASTNAME='{{ (artemis_oidc.mappings | default({})).last_name | default('family_name') }}'
+ARTEMIS_USERMANAGEMENT_OIDC_MAPPINGS_EMAIL='{{ (artemis_oidc.mappings | default({})).email | default('email') }}'
 {% endif %}
 ARTEMIS_USERMANAGEMENT_INTERNALADMIN_USERNAME='{{ artemis_internal_admin_user }}'
 ARTEMIS_USERMANAGEMENT_INTERNALADMIN_PASSWORD='{{ artemis_internal_admin_password }}'
@@ -330,6 +360,9 @@ INFO_TESTSERVER='false'
 {% endif %}
 INFO_TEXTASSESSMENTANALYTICSENABLED='true'
 INFO_LOCALLLMDEPLOYMENTENABLED='{{ artemis_local_llm_deployment_enabled | lower }}'
+{% if artemis_oidc is defined and artemis_oidc.enabled | default(false) %}
+INFO_OIDC_BUTTONLABEL='{{ artemis_oidc.button_label | default('TUM Login') }}'
+{% endif %}
 {% if is_multinode_install and artemis_eureka_urls is defined and hazelcast_address is defined %}
 EUREKA_CLIENT_ENABLED='true'
 EUREKA_CLIENT_SERVICEURL_DEFAULTZONE='{{ artemis_eureka_urls }}'


### PR DESCRIPTION
## Summary
This PR adds the necessary configuration variables to support the newly implemented OpenID Connect (OIDC) authentication layout from [PR #13169](https://github.com/ls1intum/Artemis/pull/13169) and [PR #13281](https://github.com/ls1intum/Artemis/pull/13281).

The OIDC configuration is completely feature-gated via conditional checking and is globally disabled by default. This ensures complete backward compatibility for other server instances that do not utilize external single sign-on providers.

## Changes
### `roles/artemis/defaults/main.yml`

- Introduced the `artemis_oidc` structured dictionary to house safe default properties.

- Explicitly set `enabled: false` to ensure seamless deployment fallbacks for other cluster environments.

- Added default standard OpenID Connect mapping attributes (`preferred_username`, `matriculation_number`, etc.).

### `roles/artemis/templates/application-prod.yml.j2`

- Spring Layer: Injected the `spring.security.oauth2` client registration and provider structure under the core node profile check.

- Artemis Business Logic: Placed the `user-management.oidc` feature block with active field mappings.

- Management Info Endpoint: Appended `info.oidc.buttonLabel` with strict spacing constraints

## How to Configure
To activate and test OIDC on a target environment, add the following variable block to your environment configurations:

```YAML
artemis_oidc:
  enabled: true
  button_label: "TUM Login"
  client_id: "your-artemis-client-id" <-- needs to be adjusted
  client_secret: "your-vault-encrypted-client-secret"  <-- needs to be adjusted
  issuer_uri: "https://tumidp.lrz.de/idp/shibboleth"
  authorization_uri: "https://login.tum.de/idp/profile/oidc/authorize"
  token_uri: "https://login.tum.de/idp/profile/oidc/token"
  user_info_uri: "https://login.tum.de/idp/profile/oidc/userinfo"
  jwk_set_uri: "https://login.tum.de/idp/profile/oidc/keyset"
  mappings:
    username: "preferred_username"
    matriculation_number: "matriculation_number"
    first_name: "given_name"
    last_name: "family_name"
    email: "email"
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added OpenID Connect (OIDC) login support as an alternative to LDAP, including client credentials and configurable provider endpoints.
  * Included configurable OIDC claim-to-user attribute mappings (username, matriculation number, first/last name, email) with standard defaults.
  * Exposed OIDC-related settings to the application only when OIDC is enabled, and only for provider URIs that are set.
  * Added an OIDC button label for the management **/info** page when enabled.
* **Documentation**
  * Documented the new `artemis_oidc` configuration option with an example and mapping/endpoint guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->