### PR TITLE
Privacy statement: document retention-based deletion and inactive-account cleanup (draft, needs DPO review)

### DIFF
--- a/roles/legal/files/privacy/privacy_statement_de.md
+++ b/roles/legal/files/privacy/privacy_statement_de.md
@@ -57,7 +57,7 @@ Für die optionalen KI-gestützten Funktionen (Iris, Athena) werden, sofern Nutz
 
 ### Dauer der Speicherung der personenbezogenen Daten
 
-Ihre Daten werden nur so lange gespeichert, wie dies unter Beachtung gesetzlicher Aufbewahrungsfristen zur Aufgabenerfüllung erforderlich ist. Konkrete Speicherfristen für die einzelnen Verarbeitungsvorgänge finden Sie in den jeweiligen Abschnitten unten.
+Ihre Daten werden nur so lange gespeichert, wie dies unter Beachtung gesetzlicher Aufbewahrungsfristen zur Aufgabenerfüllung erforderlich ist. Konkrete Speicherfristen für die einzelnen Verarbeitungsvorgänge finden Sie in den jeweiligen Abschnitten unten. Sobald die für einen Kurs geltende Aufbewahrungsfrist abgelaufen ist, werden die personenbezogenen Daten dieses Kurses (etwa Teilnahmen, Abgaben, Ergebnisse, Feedback und Plagiatsfälle) automatisch gelöscht, während die Kursstruktur und die Lehrmaterialien erhalten bleiben.
 
 ### Ihre Rechte
 
@@ -150,7 +150,7 @@ Die Verbindung zum LDAP-Server ist verschlüsselt (LDAPS/StartTLS), und die gesa
 
 Zusätzlich bietet Artemis **Passkeys** (WebAuthn/FIDO2) als passwortlose, phishing-resistente und datensparsame Authentifizierungsmethode an. Bei Verwendung eines Passkeys wird kein Passwort an den LDAP-Server übermittelt. Die Nutzung ist optional; Benutzername und Passwort bleiben als Alternative verfügbar. 
 
-**Speicherdauer:** Benutzername, Name, E-Mail-Adresse und Matrikelnummer werden für die Dauer der Nutzung der Plattform gespeichert. Bei Exmatrikulation oder auf Antrag werden diese Daten gelöscht, soweit keine gesetzlichen Aufbewahrungsfristen entgegenstehen. Soweit Stammdaten zur Zuordnung prüfungs- oder bewertungsrelevanter Unterlagen erforderlich sind, können sie zusammen mit diesen Unterlagen gemäß den gesetzlichen Aufbewahrungsfristen für bis zu 5 Jahre nach Ende des jeweiligen relevanten Semesters gespeichert bleiben.
+**Speicherdauer:** Benutzername, Name, E-Mail-Adresse und Matrikelnummer werden für die Dauer der Nutzung der Plattform gespeichert. Bei Exmatrikulation oder auf Antrag werden diese Daten gelöscht, soweit keine gesetzlichen Aufbewahrungsfristen entgegenstehen. Soweit Stammdaten zur Zuordnung prüfungs- oder bewertungsrelevanter Unterlagen erforderlich sind, können sie zusammen mit diesen Unterlagen gemäß den gesetzlichen Aufbewahrungsfristen für bis zu 5 Jahre nach Ende des jeweiligen relevanten Semesters gespeichert bleiben. Um die gespeicherten Daten auf das notwendige Maß zu beschränken, wird der Zeitpunkt Ihrer letzten erfolgreichen Anmeldung gespeichert und ausschließlich dazu verwendet, inaktive Konten zu identifizieren. Wenn Sie in keinem Kurs eingeschrieben sind und sich über einen längeren Zeitraum nicht angemeldet haben, kann Ihr Benutzerkonto gelöscht werden, nachdem Sie per E-Mail benachrichtigt wurden und eine Übergangsfrist abgelaufen ist; durch eine erneute Anmeldung innerhalb dieser Frist wird die Löschung abgebrochen. Administratorkonten sind davon ausgenommen.
 
 ### Profilbilder
 

--- a/roles/legal/files/privacy/privacy_statement_en.md
+++ b/roles/legal/files/privacy/privacy_statement_en.md
@@ -61,7 +61,8 @@ agreement (Auftragsverarbeitungsvertrag, AVV) between TUM and Microsoft. The dat
 ### Duration of the storage of personal data
 
 Your data will only be stored for as long as is necessary for the fulfillment of duties, taking into account statutory retention periods. Specific retention periods for the
-individual processing operations can be found in the respective sections below.
+individual processing operations can be found in the respective sections below. Once the applicable retention period for a course has elapsed, the personal data of that course (such
+as participations, submissions, results, feedback and plagiarism cases) is deleted automatically, while the course structure and the teaching materials are retained.
 
 ### Your rights
 
@@ -157,7 +158,10 @@ transmitted to the LDAP server. Use is optional; username and password remain av
 
 **Retention period:** Username, name, email address and matriculation number are stored for the duration of use of the platform. Upon exmatriculation or on request, this data is
 deleted unless statutory retention periods prevent deletion. Where master data is required to associate examination- or assessment-relevant records, it may remain stored together
-with those records pursuant to statutory retention periods for up to 5 years after the end of the respective relevant semester.
+with those records pursuant to statutory retention periods for up to 5 years after the end of the respective relevant semester. In order to keep stored data to the necessary
+minimum, the date of your last successful login is recorded and used solely to identify inactive accounts. If you are not enrolled in any course and have not logged in for a
+prolonged period, your account may be deleted after you have been notified by email and a grace period has elapsed; logging in again during this period cancels the deletion.
+Administrator accounts are excluded.
 
 ### Profile pictures
 


### PR DESCRIPTION
## Motivation

Artemis is gaining an automated, GDPR-motivated data-retention cleanup (see the Artemis PR **ls1intum/Artemis#13267**):

- Student data of a course is reset automatically once the course's retention period has elapsed (course structure and teaching materials are kept).
- Accounts that are enrolled in no course and inactive for a prolonged period are soft-deleted and anonymized, but only after a prior email warning and a grace period (logging in again cancels the deletion; administrators are excluded).
- The date of the last successful login is recorded and used solely to identify such inactive accounts.

The automation is **off by default** (per-institution kill switches), so nothing is deleted until an operator enables it. When TUM (or any deployment) enables it, the deployed privacy statement should describe these practices for transparency (GDPR Art. 13).

## What this changes

Adds matching wording to both the English and German privacy statements:

- **"Duration of the storage of personal data"**: a note that a course's personal data is deleted automatically once its retention period elapses, while the course structure and materials are retained.
- **"Login (authentication via LDAP)"**: the last-login timestamp is recorded solely to identify inactive accounts, and inactive not-enrolled accounts are deleted after a warning and grace period (login cancels it; admins excluded).

The wording is deliberately **criterion-based** (it does not hard-code the configurable retention/inactivity periods), matching how the rest of the statement is written.

## Status: DRAFT for data-protection / legal review

This is a proposed draft. The exact legal wording (EN + DE) should be confirmed by the TUM data-protection officer / legal before it is merged and deployed. It is intentionally kept minimal and additive.

Related: ls1intum/Artemis#13267

🤖 Generated with [Claude Code](https://claude.com/claude-code)