### PR TITLE
Preserve Docker's iptables rules when applying firewall rules

### DIFF
--- a/roles/firewall/README.md
+++ b/roles/firewall/README.md
@@ -32,6 +32,19 @@ You have to configure a special variable to select the firewall rule set which i
 firewall_hostgroup:  # Can be 'registry', 'nodes', 'proxy' or left blank for default rules
 ```
 
+## Interaction with Docker
+
+The rule sets in `templates/` define the whole `*filter` and `*nat` tables, so loading them with
+`iptables-restore` also removes the chains Docker installs when the daemon starts (`DOCKER`,
+`DOCKER-USER`, `DOCKER-FORWARD`, ...) together with the `MASQUERADE` rule for the bridge network.
+Docker does not notice this and only reinstalls the rules on restart, so containers lose all
+outbound connectivity in the meantime.
+
+To avoid that, this role only reloads the rules when they actually changed, and afterwards checks
+whether Docker's `MASQUERADE` rule is still present. If it is missing, Docker is restarted so it
+can reinstall its rules. Note that this restart stops running containers, which on a build agent
+means losing the builds that are currently in flight.
+
 ## Example Usage
 
 Here is an example playbook for a registry:

--- a/roles/firewall/handlers/main.yml
+++ b/roles/firewall/handlers/main.yml
@@ -1,7 +1,0 @@
----
-- name: Restart docker
-  become: true
-  service:
-    name: docker
-    state: restarted
-  when: docker_service.stat.exists is defined and docker_service.stat.exists

--- a/roles/firewall/tasks/main.yml
+++ b/roles/firewall/tasks/main.yml
@@ -20,7 +20,6 @@
     dest: /etc/iptables/rules.v4
     mode: "644"
   register: copy4
-  notify: Restart docker
 
 - name: Copy rules.v6
   become: true
@@ -29,14 +28,40 @@
     dest: /etc/iptables/rules.v6
     mode: "644"
   register: copy6
-  notify: Restart docker
 
+# Only reload when the rule set actually changed. `iptables-restore` without `--noflush`
+# replaces the whole *filter and *nat tables, which also removes the chains Docker installs
+# at daemon start (DOCKER, DOCKER-USER, DOCKER-FORWARD, ...) and the nat MASQUERADE rule for
+# the bridge network. Reloading unconditionally therefore broke container networking on every
+# repeat run of this role.
 - name: Load IPv4 rules
   become: true
   shell: "iptables-restore < /etc/iptables/rules.v4"
-  changed_when: copy4.changed
+  when: copy4.changed
 
 - name: Load IPv6 rules
   become: true
   shell: "ip6tables-restore < /etc/iptables/rules.v6"
-  changed_when: copy6.changed
+  when: copy6.changed
+
+# Docker only installs its iptables rules when the daemon starts, so it cannot recover on its
+# own once they have been flushed. Restart it whenever they are missing. This doubles as a
+# self-heal for hosts where the rules were already lost by an earlier run.
+- name: Check whether Docker's iptables rules are present
+  become: true
+  command: iptables -t nat -S POSTROUTING
+  register: docker_nat_rules
+  changed_when: false
+  failed_when: false
+  check_mode: false
+  when: docker_service.stat.exists
+
+- name: Restart docker to reinstall its iptables rules
+  become: true
+  service:
+    name: docker
+    state: restarted
+  when:
+    - docker_service.stat.exists
+    - docker_nat_rules.stdout is defined
+    - "'MASQUERADE' not in docker_nat_rules.stdout"

--- a/roles/firewall/tasks/main.yml
+++ b/roles/firewall/tasks/main.yml
@@ -34,12 +34,16 @@
 # at daemon start (DOCKER, DOCKER-USER, DOCKER-FORWARD, ...) and the nat MASQUERADE rule for
 # the bridge network. Reloading unconditionally therefore broke container networking on every
 # repeat run of this role.
-- name: Load IPv4 rules
+#
+# These deliberately are not handlers: the reload has to happen before the Docker check below,
+# while handlers only run at the end of the play. Using `meta: flush_handlers` instead would
+# also fire pending handlers of earlier roles, which is not what we want here.
+- name: Load IPv4 rules # noqa: no-handler
   become: true
   shell: "iptables-restore < /etc/iptables/rules.v4"
   when: copy4.changed
 
-- name: Load IPv6 rules
+- name: Load IPv6 rules # noqa: no-handler
   become: true
   shell: "ip6tables-restore < /etc/iptables/rules.v6"
   when: copy6.changed

--- a/roles/firewall/tasks/main.yml
+++ b/roles/firewall/tasks/main.yml
@@ -8,10 +8,9 @@
     state: latest
     update_cache: true
 
-- name: Check if docker service exists
-  stat:
-    path: /etc/systemd/system/docker.service.d/
-  register: docker_service
+- name: Gather service facts
+  become: true
+  service_facts:
 
 - name: Copy rules.v4
   become: true
@@ -58,7 +57,7 @@
   changed_when: false
   failed_when: false
   check_mode: false
-  when: docker_service.stat.exists
+  when: "'docker.service' in ansible_facts.services"
 
 - name: Restart docker to reinstall its iptables rules
   become: true
@@ -66,6 +65,6 @@
     name: docker
     state: restarted
   when:
-    - docker_service.stat.exists
+    - "'docker.service' in ansible_facts.services"
     - docker_nat_rules.stdout is defined
     - "'MASQUERADE' not in docker_nat_rules.stdout"


### PR DESCRIPTION
## Problem

The `firewall` role wipes Docker's iptables rules on every repeat run, leaving containers with no outbound networking.

The rule sets in `roles/firewall/templates/` declare the whole `*filter` and `*nat` tables. Loading them with `iptables-restore` (no `--noflush`) therefore replaces those tables entirely, removing the chains Docker installs at daemon start (`DOCKER`, `DOCKER-USER`, `DOCKER-FORWARD`, `DOCKER-BRIDGE`, `DOCKER-CT`, `DOCKER-INTERNAL`) along with the nat `MASQUERADE` rule for the bridge network. Docker only installs those rules when the daemon starts, so it cannot recover on its own.

The role tried to handle this with `notify: Restart docker`, but the two halves did not line up:

- `Load IPv4 rules` used `changed_when: copy4.changed`. `changed_when` only affects how a task is **reported**, not whether it **runs**, so the reload executed on every converge.
- The restart was notified by the *template* task, which is only `changed` when the rendered file content changes.

So the first converge repaired itself and every subsequent one silently broke container networking. Handlers also only flush at the end of the play, so any later role in the same play already ran against a broken network.

## Impact

This took out all 20 Artemis production build agents on 2026-07-24. The playbook ran twice within 40 seconds; the first run reloaded the rules and restarted Docker, the second reloaded them again with no restart:

```
08:34:14  iptables-restore < /etc/iptables/rules.v4   flushes Docker's chains (file changed)
08:34:18  docker.service stopping                     handler fires
08:34:20  docker.service started                      Docker reinstalls its chains
08:34:45  (role runs a second time)
08:34:52  iptables-restore < /etc/iptables/rules.v4   flushes them again (file unchanged, no notify)
          ...no docker restart                        broken from here on
```

Every agent was left with `masq=0 dockerfwd=0`. Build containers could not resolve DNS or reach Maven Central and the Gradle plugin portal, which surfaced as `Temporary failure in name resolution` and `Plugin [id: '...'] was not found in any of the following sources`. Because packets were dropped rather than rejected, each additional repository added a full timeout instead of failing fast.

Reported in ls1intum/Artemis#13306, ls1intum/Artemis#13308 and ls1intum/Artemis#13310.

## Solution

- Reload the rules only when they actually changed (`when:` instead of `changed_when:`), which makes the role idempotent.
- After the reload, check whether Docker's `MASQUERADE` rule is still present and restart Docker if it is not. This runs as an explicit task right after the reload rather than as an end-of-play handler, and doubles as a self-heal for hosts whose rules were already lost.
- Drop the now-unused handler, so the change path cannot trigger a second, redundant restart.
- Document the Docker interaction in the role README, including the caveat that restarting Docker stops in-flight builds on a build agent.

## Alternatives considered

Dropping the empty `*nat` section from the templates would stop `iptables-restore` from touching the nat table, but the `*filter` restore still removes Docker's filter chains and resets the `FORWARD` policy to `DROP`, so a restart is needed regardless. Left the templates untouched to keep the rendered rule sets identical and avoid an unnecessary reload on the next converge.

## Testing

- `iptables-restore` was confirmed on a production agent to remove `nat POSTROUTING ... MASQUERADE` and the `FORWARD -j DOCKER-FORWARD` jump.
- Verified from inside a container on a healthy vs. a broken agent: healthy resolved `repo.maven.apache.org` and returned `200`, broken failed name resolution and timed out on raw TCP to the DNS server.
- All 20 production agents were remediated with `systemctl restart docker` and re-verified: `masq=1`, `fwd=1`, and `maven=200 gradle=200` from inside a container on every agent.

## Note for maintainers

`galaxy.yml` is not bumped here, since version bumps appear to be made in separate commits in this repo. Consumers pinning the collection will need a release to pick this up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved firewall rule updates to preserve Docker networking and container outbound connectivity.
  * Firewall rules are now reloaded only when changes are detected.
  * Added automatic recovery when Docker’s required network masquerading rule is missing.
* **Documentation**
  * Added guidance on Docker interaction, including how rule reloads and Docker restarts can affect running containers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->