### PR TITLE
Point nginx auth rate limits at the endpoints actually served

### DIFF
--- a/roles/proxy/templates/nginx_proxy.conf.j2
+++ b/roles/proxy/templates/nginx_proxy.conf.j2
@@ -132,12 +132,22 @@ server {
 		# If an attacker spams this endpoint, only the first three requests will come through.
 		# This only resets if the violation of the rate limit stops.
         limit_req zone=loginlimit burst=3 delay=2;
+
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
     }
 
     # SAML2 login callback: exchanges an established SAML2 context for an Artemis JWT cookie.
     location /api/core/public/saml2 {
         proxy_pass {{ proxy_node_protocol }}://app/api/core/public/saml2;
         limit_req zone=loginlimit burst=3 delay=2;
+
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
     }
 
     # Account recovery and registration. Each of these either sends mail to a user-supplied address or
@@ -147,21 +157,41 @@ server {
     location /api/core/public/account/reset-password/init {
         proxy_pass {{ proxy_node_protocol }}://app/api/core/public/account/reset-password/init;
         limit_req zone=accountrecoverylimit burst=3 nodelay;
+
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
     }
 
     location /api/core/public/account/reset-password/finish {
         proxy_pass {{ proxy_node_protocol }}://app/api/core/public/account/reset-password/finish;
         limit_req zone=accountrecoverylimit burst=3 nodelay;
+
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
     }
 
     location /api/core/public/register {
         proxy_pass {{ proxy_node_protocol }}://app/api/core/public/register;
         limit_req zone=accountrecoverylimit burst=3 nodelay;
+
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
     }
 
     location /api/core/public/activate {
         proxy_pass {{ proxy_node_protocol }}://app/api/core/public/activate;
         limit_req zone=accountrecoverylimit burst=3 nodelay;
+
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
     }
 
     location /login/webauthn {
@@ -173,6 +203,11 @@ server {
 		# If an attacker spams this endpoint, only the first three requests will come through.
 		# This only resets if the violation of the rate limit stops.
         limit_req zone=loginlimit burst=3 delay=2;
+
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
     }
 
     # Git credential handshake. Every git-over-HTTP operation starts with exactly one /info/refs

--- a/roles/proxy/templates/nginx_proxy.conf.j2
+++ b/roles/proxy/templates/nginx_proxy.conf.j2
@@ -29,10 +29,24 @@ map $rate_limit_exempt $rate_limit_key {
 }
 {% endif %}
 
+# Answer throttled requests with 429 rather than nginx's default of 503. 503 reads as "the server is
+# down", so clients and monitoring retry it; 429 is the honest status and matches what the Artemis
+# application-level limiter returns (RateLimitExceededException -> 429).
+limit_req_status 429;
+
 # Rate limit for the login REST call, at most one requests per two seconds
 limit_req_zone $binary_remote_addr zone=loginlimit:10m rate=30r/m;
-# Rate limit for git operations, at most 15 requests per second
-limit_req_zone {% if proxy_rate_limit_exempt_ips | length > 0 %}$rate_limit_key{% else %}$binary_remote_addr{% endif %} zone=gitlimit:10m rate=15r/s;
+# Rate limit for account recovery and registration (password reset init/finish, register, activate).
+# Stricter than the login zone: these endpoints send mail and mutate credentials, and no legitimate
+# client calls them repeatedly. Deliberately not exemptible - no automation uses them.
+limit_req_zone $binary_remote_addr zone=accountrecoverylimit:10m rate=5r/m;
+# Rate limit for the git credential handshake (/info/refs). Every git-over-HTTP operation starts with
+# exactly one such request, and it is the one that carries credentials, so it is bounded separately from
+# the bulk transfer below - which has to stay generous for real clones and pushes. One handshake per
+# second per client is well above interactive use.
+limit_req_zone {% if proxy_rate_limit_exempt_ips | length > 0 %}$rate_limit_key{% else %}$binary_remote_addr{% endif %} zone=gitauthlimit:10m rate=60r/m;
+# Rate limit for git data transfer, at most 5 requests per second
+limit_req_zone {% if proxy_rate_limit_exempt_ips | length > 0 %}$rate_limit_key{% else %}$binary_remote_addr{% endif %} zone=gitlimit:10m rate=5r/s;
 
 server {
     listen 80 default_server;
@@ -105,8 +119,12 @@ server {
     }
 {% endif %}
 
-    location /api/authenticate {
-        proxy_pass http://app/api/authenticate;
+    # Password login. NOTE: the path must match the endpoint PublicUserJwtResource actually serves
+    # (@RequestMapping("api/core/public/") + @PostMapping("authenticate")). Nothing serves the former
+    # /api/authenticate path, so a block pointing at it silently throttles nothing and login requests
+    # fall through to `location /` unlimited. If the endpoint moves, move this block with it.
+    location /api/core/public/authenticate {
+        proxy_pass {{ proxy_node_protocol }}://app/api/core/public/authenticate;
 		# For a given violation of the rate limit defined in the zone
 		# * the first 2 (delay) requests will be allowed without delay
 		# * the next (burst - delay) request waits until it fits in the rate limit
@@ -114,10 +132,40 @@ server {
 		# If an attacker spams this endpoint, only the first three requests will come through.
 		# This only resets if the violation of the rate limit stops.
         limit_req zone=loginlimit burst=3 delay=2;
+    }
+
+    # SAML2 login callback: exchanges an established SAML2 context for an Artemis JWT cookie.
+    location /api/core/public/saml2 {
+        proxy_pass {{ proxy_node_protocol }}://app/api/core/public/saml2;
+        limit_req zone=loginlimit burst=3 delay=2;
+    }
+
+    # Account recovery and registration. Each of these either sends mail to a user-supplied address or
+    # mutates credentials, so they get the strict zone. Listed individually on purpose: a broader
+    # /api/core/public/ prefix would also catch GET /api/core/public/account, which the client requests
+    # on every page load, and /account/change-language.
+    location /api/core/public/account/reset-password/init {
+        proxy_pass {{ proxy_node_protocol }}://app/api/core/public/account/reset-password/init;
+        limit_req zone=accountrecoverylimit burst=3 nodelay;
+    }
+
+    location /api/core/public/account/reset-password/finish {
+        proxy_pass {{ proxy_node_protocol }}://app/api/core/public/account/reset-password/finish;
+        limit_req zone=accountrecoverylimit burst=3 nodelay;
+    }
+
+    location /api/core/public/register {
+        proxy_pass {{ proxy_node_protocol }}://app/api/core/public/register;
+        limit_req zone=accountrecoverylimit burst=3 nodelay;
+    }
+
+    location /api/core/public/activate {
+        proxy_pass {{ proxy_node_protocol }}://app/api/core/public/activate;
+        limit_req zone=accountrecoverylimit burst=3 nodelay;
     }
 
     location /login/webauthn {
-        proxy_pass http://app/login/webauthn;
+        proxy_pass {{ proxy_node_protocol }}://app/login/webauthn;
 		# For a given violation of the rate limit defined in the zone
 		# * the first 2 (delay) requests will be allowed without delay
 		# * the next (burst - delay) request waits until it fits in the rate limit
@@ -127,12 +175,32 @@ server {
         limit_req zone=loginlimit burst=3 delay=2;
     }
 
+    # Git credential handshake. Every git-over-HTTP operation starts with exactly one /info/refs
+    # request, and it is the one that carries credentials. The bulk zone below has to stay generous for
+    # real clones and pushes, so the handshake is bounded separately and more tightly.
+    #
+    # A regex location takes precedence over the /git/ prefix location, so this wins for /info/refs.
+    # proxy_pass must have no URI part in a regex location, which passes the original URI unchanged -
+    # equivalent to the identity mapping the prefix block does.
+    location ~ ^/git/.*/info/refs$ {
+        proxy_pass {{ proxy_node_protocol }}://app;
+        limit_req zone=gitauthlimit burst=10 nodelay;
+
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_send_timeout 900s;
+        proxy_read_timeout 900s;
+    }
+
     location /git/ {
-        proxy_pass http://app/git/;
+        proxy_pass {{ proxy_node_protocol }}://app/git/;
         # For a given violation of the rate limit defined in the zone
         # * the first 30 requests will be allowed without delay
         # * the rest will be denied
         # This only resets if the violation of the rate limit stops.
+        # NOTE: this bounds data-transfer volume; the handshake above is bounded separately.
         limit_req zone=gitlimit burst=30 nodelay;
 
         proxy_http_version 1.1;


### PR DESCRIPTION
### Motivation

The login `limit_req` block targets `location /api/authenticate`, but no Artemis controller serves that path — `PublicUserJwtResource` is mapped at `api/core/public/` + `authenticate`. nginx matches locations by URI prefix, so login requests never enter that block and fall through to `location /`, which has no `limit_req` at all. The neighbouring `/login/webauthn` block *does* match its endpoint, which is part of why the login block looks maintained.

While fixing that, the surrounding endpoints deserve the same treatment: several other public Artemis endpoints either authenticate a caller or change a credential, and none was throttled at the proxy.

### Description

**Fix the stale path** — `location /api/authenticate` → `/api/core/public/authenticate`, with a comment tying it to the controller mapping so it does not drift again.

**Cover the remaining auth-relevant endpoints**, enumerated from the Artemis controllers rather than guessed:
- `/api/core/public/saml2` joins the existing `loginlimit` zone.
- Password reset `init`/`finish`, `register` and `activate` get a new, stricter `accountrecoverylimit` zone (5r/m).

Listed individually rather than as one `/api/core/public/` prefix **on purpose**: a prefix would also catch `GET /api/core/public/account`, which the client requests on every page load, and `/account/change-language`.

**`limit_req_status 429`** — nginx answers throttled requests with 503 by default, which reads as "the server is down" and gets retried by clients and monitoring. It also disagreed with the Artemis application-level limiter, which already returns 429.

**Split the git limit rather than lowering it.** Every git-over-HTTP operation begins with exactly one `/info/refs` request, and that is the one carrying credentials, while the bulk zone has to stay generous for real clones and pushes. `/info/refs` now uses a separate `gitauthlimit` (60r/m) via a regex location; the transfer zone goes 15r/s → 5r/s. **Both git zones keep going through the existing `proxy_rate_limit_exempt_ips` mechanism**, so build agents can be exempted from either — worth confirming your exempt list covers them before this rolls out.

**Drive-by:** the rate-limited location blocks hardcoded `http://app`, unlike `location /` which uses `{{ proxy_node_protocol }}`. They would have broken if that variable were ever set to `https`, so they now use it too.

The matching change to the reference Docker nginx config is in ls1intum/Artemis#13387.

### Testing

Rendered the template with the production-shaped variables and ran `nginx -t` over the output — passes. Then drove a container with the rendered config against a stub upstream (404 = passed through to the absent upstream, 429 = throttled):

```
/api/core/public/account/reset-password/init   404 404 404 404 429 429 ...   throttled after burst
/api/core/public/activate                      429 ...                       shares the zone
/git/PROJ/proj-student.git/info/refs           404 x11 then 429              handshake throttled
/git/PROJ/proj-student.git/git-upload-pack     404 x12                       transfer unaffected
/api/core/public/account   (control)           404 x12                       NOT throttled
```

### Before merging / rolling out

- [ ] Confirm `proxy_rate_limit_exempt_ips` covers the build agents (the git transfer zone drops from 15r/s to 5r/s)
- [ ] Run the role against a test proxy and confirm login, `git clone` and `git push` all still work
- [ ] Confirm normal page loads are not throttled

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added rate-limit handling for login, account recovery, registration, SAML2, activation, and Git operations.
  * Rate-limit violations now return HTTP 429 responses.
  * Added separate protections for Git authentication requests and bulk data transfers.

* **Bug Fixes**
  * Corrected login request routing.
  * Improved handling of exempt IP addresses.
  * Proxy connections now respect the configured protocol.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->