### PR TITLE
`Weaviate`: Raise configurable HTTP rate limits

### DIFF
--- a/roles/weaviate/defaults/main.yml
+++ b/roles/weaviate/defaults/main.yml
@@ -41,6 +41,10 @@ letsencrypt_email: # FIXME - e.g., your-email@example.com
 #   Private networks: "10.0.0.0/8,192.168.0.0/16,172.16.0.0/12"
 weaviate_allowed_ips: ""
 
+# HTTP request limits enforced by Traefik per source.
+weaviate_rate_limit_average: 1000
+weaviate_rate_limit_burst: 2000
+
 ##############################################################################
 # Multi2vec-CLIP Configuration
 ##############################################################################

--- a/roles/weaviate/templates/config.yml.j2
+++ b/roles/weaviate/templates/config.yml.j2
@@ -20,9 +20,9 @@ http:
 
     rate-limit:
       rateLimit:
-        average: 100
+        average: {{ weaviate_rate_limit_average }}
         period: 1s
-        burst: 200
+        burst: {{ weaviate_rate_limit_burst }}
 
     default-whitelist:
       ipAllowList:


### PR DESCRIPTION
## Summary

- make the Traefik HTTP rate-limit average and burst configurable through role defaults
- raise the defaults from 100 to 1000 requests per second and from 200 to 2000 burst
- keep the existing one-second period and middleware ordering

## Motivation

Pyris performs bursty Weaviate object updates for lecture visibility synchronization. The previous 100 requests/s and 200 burst limits caused HTTP 429 responses even while the Weaviate node itself had ample capacity.

The matching production and test values were applied directly as an immediate operational mitigation. This change prevents a future Ansible run from reverting them.

## Verification

- rendered `roles/weaviate/templates/config.yml.j2` with the role defaults and verified the resulting YAML contains `average: 1000`, `period: 1s`, and `burst: 2000`
- verified comma-separated IP allowlist rendering remains unchanged
- `ansible-lint roles/weaviate`
- live read-only burst check from Pyris to both production and test: 400/400 HTTP 200 responses


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable HTTP request rate limiting for the service.
  * Set default limits of 1,000 requests per second, with a burst allowance of 2,000 requests.

* **Improvements**
  * Rate-limit values can now be adjusted through configuration instead of being fixed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->