### PR TITLE
`Development`: Remove legacy Artemis configuration for build agent authentication

### DIFF
--- a/roles/artemis/templates/application-prod.yml.j2
+++ b/roles/artemis/templates/application-prod.yml.j2
@@ -206,10 +206,6 @@ artemis:
 {% if version_control.localvc.use_version_control_access_token is defined %}
     use-version-control-access-token: {{ version_control.localvc.use_version_control_access_token | lower }}
 {% endif %}
-{% if artemis_computed_is_core_node or (version_control.localvc.build_agent_git_credentials is not defined and version_control.localvc.build_agent_use_ssh is not defined) %}
-    user: {{ artemis_internal_admin_user }}
-    password: {{ artemis_internal_admin_password }}
-{% endif %}
 {% if version_control.localvc.build_agent_git_credentials is defined %}
     build-agent-git-username: {{ version_control.localvc.build_agent_git_credentials.user }}
     build-agent-git-password: {{ version_control.localvc.build_agent_git_credentials.password }}

--- a/roles/artemis/templates/artemis.env.j2
+++ b/roles/artemis/templates/artemis.env.j2
@@ -127,10 +127,6 @@ ARTEMIS_VERSIONCONTROL_LOCALVCSREPOPATH='{{ artemis_repo_basepath }}/local-vcs-r
 {% if version_control.localvc.use_version_control_access_token is defined %}
 ARTEMIS_VERSIONCONTROL_USEVERSIONCONTROLACCESSTOKEN='{{ version_control.localvc.use_version_control_access_token | lower }}'
 {% endif %}
-{% if artemis_computed_is_core_node or (version_control.localvc.build_agent_git_credentials is not defined and version_control.localvc.build_agent_use_ssh is not defined) %}
-ARTEMIS_VERSIONCONTROL_USER='{{ artemis_internal_admin_user }}'
-ARTEMIS_VERSIONCONTROL_PASSWORD='{{ artemis_internal_admin_password }}'
-{% endif %}
 {% if version_control.localvc.build_agent_git_credentials is defined %}
 ARTEMIS_VERSIONCONTROL_BUILDAGENTGITUSERNAME='{{ version_control.localvc.build_agent_git_credentials.user }}'
 ARTEMIS_VERSIONCONTROL_BUILDAGENTGITPASSWORD='{{ version_control.localvc.build_agent_git_credentials.password }}'


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Removed automatic fallback credentials from local version-control configuration.
  - Version-control settings no longer inherit internal administrator credentials when dedicated build-agent credentials are unavailable.
  - Prevents unintended credential propagation in application and environment configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->