### PR TITLE
`Proxy`: Announce the real ssh client to Artemis with the PROXY protocol

### DIFF
--- a/roles/artemis/README.md
+++ b/roles/artemis/README.md
@@ -72,6 +72,10 @@ localvc:
   ssh_key_path: "/opt/artemis/ssh-keys" # Key path for the SSH host keys
   build_agent_use_ssh: true # Setting whether SSH should be used.
   ssh_url: "ssh://git@artemis.example.com:7921/" # URL template for SSH clone operations.
+  # Proxies that forward port 7921 at the TCP level and announce the real client with a PROXY protocol header.
+  # Only set this together with proxy_ssh_proxy_protocol on those proxies; enabling one half breaks SSH.
+  ssh_proxy_protocol_trusted_sources:
+    - "10.0.0.1"
   build_agent_git_credentials:
     user: "build_agent_user"
     password: "build_agent_password"

--- a/roles/artemis/templates/application-prod.yml.j2
+++ b/roles/artemis/templates/application-prod.yml.j2
@@ -262,6 +262,13 @@ artemis:
 {% if version_control.localvc.ssh_url is defined %}
     ssh-template-clone-url: {{ version_control.localvc.ssh_url }}
 {% endif %}
+{% if version_control.localvc.ssh_proxy_protocol_trusted_sources | default([], true) | length > 0 %}
+    ssh-proxy-protocol:
+      trusted-sources:
+{% for trusted_source in version_control.localvc.ssh_proxy_protocol_trusted_sources %}
+        - "{{ trusted_source }}"
+{% endfor %}
+{% endif %}
     repository-authentication-mechanisms: {{ version_control.localvc.repository_authentication_mechanisms | default("token,ssh,password") }}
 {% endif %}
 

--- a/roles/artemis/templates/artemis.env.j2
+++ b/roles/artemis/templates/artemis.env.j2
@@ -173,6 +173,9 @@ ARTEMIS_VERSIONCONTROL_SSHHOSTKEYPATH='{{ artemis_repo_basepath }}/ssh-keys'
 {% if version_control.localvc.ssh_url is defined %}
 ARTEMIS_VERSIONCONTROL_SSHTEMPLATECLONEURL='{{ version_control.localvc.ssh_url }}'
 {% endif %}
+{% if version_control.localvc.ssh_proxy_protocol_trusted_sources | default([], true) | length > 0 %}
+ARTEMIS_VERSIONCONTROL_SSHPROXYPROTOCOL_TRUSTEDSOURCES='{{ version_control.localvc.ssh_proxy_protocol_trusted_sources | join(",") }}'
+{% endif %}
 ARTEMIS_VERSIONCONTROL_REPOSITORYAUTHENTICATIONMECHANISMS='{{ version_control.localvc.repository_authentication_mechanisms | default("token,ssh,password") }}'
 {% endif %}
 {% if continuous_integration.localci is defined %}

--- a/roles/proxy/README.md
+++ b/roles/proxy/README.md
@@ -143,8 +143,13 @@ version_control:
 ```
 
 An Artemis node refuses an SSH connection that arrives from a listed address without a valid header, and treats a
-connection from any other address as ordinary SSH. Connections that bypass the proxy are therefore unaffected, and a
-header cannot be forged by someone who reaches port 7921 directly.
+connection from any other address as ordinary SSH. Connections that bypass the proxy are therefore unaffected.
+
+A PROXY protocol header carries no signature and no shared secret, so nothing about the header itself proves it is
+genuine. What makes it trustworthy is only which source addresses may send one, and a TCP source address cannot be
+forged without being on the network path. The consequence is that anything able to connect from a listed address can
+name any client address it likes: list the proxy's single address rather than a whole subnet, and restrict port 7921 at
+the firewall so that only the proxy can reach it.
 
 > [!WARNING]
 > Enable both halves in the same deployment. `proxy_ssh_proxy_protocol: true` without

--- a/roles/proxy/README.md
+++ b/roles/proxy/README.md
@@ -11,6 +11,7 @@ To configure the role, you need to set the required variables in your Ansible pl
 - `proxy_available_nodes`: A list of nodes for load balancing, either defined as a host-group or manually listed.
 - `proxy_target_port`: The service port on nodes for load balancing.
 - `proxy_forward_ssh`: Whether to enable port forwarding for SSH Git communication with Artemis ICL LocalVC.
+- `proxy_ssh_proxy_protocol`: Whether to announce the real SSH client to the Artemis nodes using the PROXY protocol. Defaults to `false`. Enable it only together with `version_control.localvc.ssh_proxy_protocol_trusted_sources` on the Artemis nodes; see [SSH behind a load balancer](#ssh-behind-a-load-balancer).
 - `proxy_node_protocol`: The protocol used to communicate with nodes (either http or https).
 - `proxy_mailto`: A valid mail address used for the /mailto endpoint.
 - `proxy_resolver`: The resolver configuration for nginx.
@@ -52,6 +53,10 @@ proxy_target_port: 8080
 
 # Port forwarding configuration of Artemis nodes for SSH Git communication with Artemis ICL LocalVC
 proxy_forward_ssh: true
+
+# Announce the real ssh client to the Artemis nodes using the PROXY protocol.
+# Only enable together with version_control.localvc.ssh_proxy_protocol_trusted_sources on the nodes.
+proxy_ssh_proxy_protocol: false
 
 # Protocol used to communicate with nodes (either http or https)
 proxy_node_protocol: http
@@ -114,3 +119,34 @@ Here is an example playbook:
         fastcgi_send_timeout: "900s"
         fastcgi_read_timeout: "900s"
 ```
+
+## SSH behind a load balancer
+
+`proxy_forward_ssh` forwards port 7921 at the TCP level, which hides the client from the Artemis nodes: every SSH
+connection appears to come from this proxy. That means git SSH rate limiting shares a single bucket across all users,
+the VCS access log records the proxy rather than the person, and Artemis cannot tell which address a build agent
+connects from.
+
+Setting `proxy_ssh_proxy_protocol: true` makes nginx prepend a HAProxy PROXY protocol header naming the real client.
+The Artemis nodes only believe that header from addresses they are told to expect it from, so both sides have to be
+configured:
+
+```yaml
+# on the proxy
+proxy_ssh_proxy_protocol: true
+
+# on the Artemis nodes
+version_control:
+  localvc:
+    ssh_proxy_protocol_trusted_sources:
+      - "10.0.0.1"  # the address of the proxy above
+```
+
+An Artemis node refuses an SSH connection that arrives from a listed address without a valid header, and treats a
+connection from any other address as ordinary SSH. Connections that bypass the proxy are therefore unaffected, and a
+header cannot be forged by someone who reaches port 7921 directly.
+
+> [!WARNING]
+> Enable both halves in the same deployment. `proxy_ssh_proxy_protocol: true` without
+> `ssh_proxy_protocol_trusted_sources` breaks every SSH connection through this proxy, and the reverse refuses them on
+> the node. Requires an Artemis version whose SSH listener supports the PROXY protocol.

--- a/roles/proxy/defaults/main.yml
+++ b/roles/proxy/defaults/main.yml
@@ -26,6 +26,15 @@ proxy_target_port: 8080
 # Port forwarding configuration of Artemis nodes for SSH Git communication with Artemis ICL LocalVC
 proxy_forward_ssh: true
 
+# Whether to announce the real ssh client to the Artemis nodes using the HAProxy PROXY protocol.
+# Forwarding port 7921 at the TCP level otherwise hides the client, so every ssh connection appears to come from this
+# proxy: git ssh rate limiting shares a single bucket across all users, and Artemis cannot check which address a build
+# agent connects from.
+# Only enable this together with version_control.localvc.ssh_proxy_protocol_trusted_sources on the Artemis nodes,
+# listing this proxy. Enabling one half without the other breaks ssh in one direction or the other, which is why this
+# defaults to false. Requires an Artemis version that supports the PROXY protocol on its ssh listener.
+proxy_ssh_proxy_protocol: false
+
 # Protocol used to communicate with nodes (either http or https)
 proxy_node_protocol: http
 

--- a/roles/proxy/tasks/nginx.yml
+++ b/roles/proxy/tasks/nginx.yml
@@ -129,6 +129,12 @@
           listen 7921;
           listen [::]:7921;
           proxy_pass artemis_ssh;
+          # Announce the real client to the Artemis ssh server. Without this, a TCP proxy_pass hides it and every
+          # ssh connection is attributed to this proxy: git ssh rate limiting shares one bucket across all users,
+          # the access log records the proxy, and Artemis cannot tell which build agent a connection came from.
+          # Requires artemis.version-control.ssh-proxy-protocol.trusted-sources to list this proxy on the nodes,
+          # which is why it is off by default: enabling only one of the two halves breaks ssh.
+          proxy_protocol {{ 'on' if proxy_ssh_proxy_protocol else 'off' }};
         }
       }
   when: proxy_forward_ssh


### PR DESCRIPTION
### Problem

`proxy_forward_ssh` forwards port 7921 with a plain TCP `proxy_pass`, which hides the client from the Artemis nodes. Every ssh connection is attributed to the proxy, so:

- git ssh rate limiting shares a **single bucket across all users**, because Artemis buckets per client address
- the VCS access log records the proxy instead of the person
- Artemis cannot tell which address a build agent connects from, which the new build agent origin checks depend on (ls1intum/Artemis#13503 follow-up)

### Solution

Add `proxy_ssh_proxy_protocol` (default `false`), which makes nginx prepend a HAProxy PROXY protocol header naming the real client.

Artemis only believes that header from addresses it is told to expect it from, so **both halves are in this PR**:

| Role | Change |
|---|---|
| `proxy` | `proxy_protocol on\|off;` in the ssh `stream` block |
| `artemis` | renders `artemis.version-control.ssh-proxy-protocol.trusted-sources` into both `application-prod.yml` and `artemis.env` |

Enabling only one half breaks ssh in one direction or the other, which is why the default is `false` and both READMEs say so explicitly. Keying acceptance on the source address rather than on the presence of a header is deliberate: believing a header from any sender would let anyone who can reach port 7921 claim an arbitrary client address, which would defeat the origin check it exists to support.

The nginx directive is always rendered, as `on` or `off`, so the deployed configuration states which mode is in effect rather than leaving it to the nginx default.

### Usage

```yaml
# on the proxy
proxy_ssh_proxy_protocol: true

# on the Artemis nodes
version_control:
  localvc:
    ssh_proxy_protocol_trusted_sources:
      - "10.0.0.1"   # the proxy
```

Connections that bypass the proxy keep working as ordinary ssh, so this is safe to roll out to the nodes first and the proxy second.

### Requires

An Artemis version whose ssh listener supports the PROXY protocol. Until that ships, leave `proxy_ssh_proxy_protocol` at its default and the rendered config is unchanged apart from an explicit `proxy_protocol off;`.

### Testing

- `ansible-lint roles/proxy roles/artemis` passes on the `production` profile, 0 failures
- Rendered every branch of both Jinja templates and asserted the output: with several sources, with the key absent, with the key set to `null`, and with an empty list. The `| default([], true) | length > 0` guard is what makes the `null` case (a plausible inventory mistake) render nothing instead of failing the play; it matches the existing idiom in these templates
- Verified the generated `application-prod.yml` fragment parses as YAML and yields the expected nested structure
- End to end against the Artemis multi-node stack with `proxy_protocol on` in nginx: both Playwright ssh git submission tests (RSA and ED25519) pass through the proxy, and the ssh server sees the student rather than the load balancer